### PR TITLE
Compiler error with LLVM 4.1 and ARC: "Cast of 'int' to 'OHHTTPStubsResponse *' is disallowed with ARC

### DIFF
--- a/OHHTTPStubs/OHHTTPStubsResponse.h
+++ b/OHHTTPStubs/OHHTTPStubsResponse.h
@@ -33,7 +33,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Defines & Constants
 
-#define OHHTTPStubsResponseUseStub (OHHTTPStubsResponse*)1
+#define OHHTTPStubsResponseUseStub (OHHTTPStubsResponse*)@(1)
 #define OHHTTPStubsResponseDontUseStub (OHHTTPStubsResponse*)nil
 
 // Standard download speeds.


### PR DESCRIPTION
Fixed by turning the int into an NSNumber (using object literal syntax... not sure if this is in line with the library's requirements, otherwise it will work the same with [NSNumber numberWithInt: 1]
