### PR TITLE
Make sure request and response times are never negative

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.m
+++ b/OHHTTPStubs/OHHTTPStubs.m
@@ -245,8 +245,8 @@
             double bandwidth = -canonicalResponseTime * 1000.0; // in bytes per second
             canonicalResponseTime = responseStub.responseData.length / bandwidth;
         }
-        NSTimeInterval requestTime = canonicalResponseTime * 0.1;
-        NSTimeInterval responseTime = canonicalResponseTime - requestTime;
+        NSTimeInterval requestTime = fabs(canonicalResponseTime * 0.1);
+        NSTimeInterval responseTime = fabs(canonicalResponseTime - requestTime);
         
         NSHTTPURLResponse* urlResponse = [[NSHTTPURLResponse alloc] initWithURL:request.URL
                                                                      statusCode:responseStub.statusCode


### PR DESCRIPTION
Who knows what could happen then (especially when calling private APIs).
