### PR TITLE
Override the NSURLProtocol initializer

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.m
+++ b/OHHTTPStubs/OHHTTPStubs.m
@@ -211,6 +211,11 @@
     return (response != nil);
 }
 
+- (id)initWithRequest:(NSURLRequest *)request cachedResponse:(NSCachedURLResponse *)response client:(id<NSURLProtocolClient>)client
+{
+    return [super initWithRequest:request cachedResponse:nil client:client];
+}
+
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
 {
 	return request;


### PR DESCRIPTION
Make super sure that we never use a cached response.

This is mostly a bit of defensive programming. I haven't noticed any consistently bad behavior from not doing this, but why not?
