### PR TITLE
Remove use of NSHTTPURLResponse private initializer

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.m
+++ b/OHHTTPStubs/OHHTTPStubs.m
@@ -184,19 +184,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Private Protocol Class
 
-// Undocumented initializer obtained by class-dump
-// Don't use this in production code destined for the App Store
-#if ! DEBUG
-#warning This code uses a private method: use only for you app testing. Don't use OHHTTPStubs when publishing your app on the App Store.
-#endif
-
-@interface NSHTTPURLResponse(UndocumentedInitializer)
-- (id)initWithURL:(NSURL*)URL
-       statusCode:(NSInteger)statusCode
-     headerFields:(NSDictionary*)headerFields
-      requestTime:(double)requestTime;
-@end
-
 @implementation OHHTTPStubsProtocol
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
@@ -250,8 +237,8 @@
         
         NSHTTPURLResponse* urlResponse = [[NSHTTPURLResponse alloc] initWithURL:request.URL
                                                                      statusCode:responseStub.statusCode
-                                                                   headerFields:responseStub.httpHeaders
-                                                                    requestTime:requestTime];
+                                                                    HTTPVersion:@"HTTP/1.1"
+                                                                   headerFields:responseStub.httpHeaders];
         
         // Cookies handling
         if (request.HTTPShouldHandleCookies)


### PR DESCRIPTION
It's not that useful, and we really have no guarantees about how it behaves. There's a public one that's very similar, so let's use that one instead.
