### PR TITLE
Allow users to execute responses arbitrarily.

### DIFF
--- a/OHHTTPStubs/OHHTTPStubsResponse.h
+++ b/OHHTTPStubs/OHHTTPStubsResponse.h
@@ -29,6 +29,11 @@
 #import <Foundation/Foundation.h>
 
 ////////////////////////////////////////////////////////////////////////////////
+#pragma mark - Types
+
+typedef void(^OHHTTPStubsResponder)(dispatch_block_t respondBlock);
+
+////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Defines & Constants
 
 // Standard download speeds.
@@ -58,6 +63,7 @@ OHHTTPStubsDownloadSpeedWifi;
 //! @note if responseTime<0, it is interpreted as a download speed in KBps ( -200 => 200KB/s )
 @property(nonatomic, assign) NSTimeInterval responseTime;
 @property(nonatomic, strong) NSError* error;
+@property(nonatomic, copy) OHHTTPStubsResponder responder;
 
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Class Methods

--- a/OHHTTPStubs/UnitTests/AsyncSenTestCase.h
+++ b/OHHTTPStubs/UnitTests/AsyncSenTestCase.h
@@ -30,5 +30,9 @@
 -(void)waitForAsyncOperationWithTimeout:(NSTimeInterval)timeout; //!< Wait for one async operation
 -(void)waitForAsyncOperations:(NSUInteger)count withTimeout:(NSTimeInterval)timeout; //!< Wait for multiple async operations
 -(void)waitForTimeout:(NSTimeInterval)timeout; //!< Wait for a fixed amount of time
+-(id)waitForAsyncOperationObjectWithTimeout:(NSTimeInterval)timeout; //!< Wait for one async operation that returns a value with notifyAsyncOperationDoneWithObject:
+-(NSDictionary *)waitForAsyncOperationObjects:(NSUInteger)count withTimeout:(NSTimeInterval)timeout; //!< Wait for multiple async operations that return a value with notifyAsyncOperationDoneWithObject:forKey:
 -(void)notifyAsyncOperationDone; //!< notify any waiter that the async op is done
+-(void)notifyAsyncOperationDoneWithObject:(id)object; //!< notify any waiter that the async op is done and returned the given value.
+-(void)notifyAsyncOperationDoneWithObject:(id)object forKey:(NSString *)key;  //!< notify any waiter that the async op is done and returned the given value for the given key.
 @end

--- a/OHHTTPStubs/UnitTests/Test Suites/AFNetworkingTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/AFNetworkingTests.m
@@ -29,6 +29,8 @@
 
 @interface AFNetworkingTests : AsyncSenTestCase @end
 
+static const NSTimeInterval kResponseTimeTolerence = 0.5;
+
 @implementation AFNetworkingTests
 
 -(void)test_AFHTTPRequestOperation
@@ -53,7 +55,46 @@
     }];
     [op start];
     
-    [self waitForAsyncOperationWithTimeout:kResponseTime+0.5];
+    [self waitForAsyncOperationWithTimeout:kResponseTime+kResponseTimeTolerence];
+    
+    STAssertEqualObjects(response, expectedResponse, @"Unexpected data received");
+}
+
+-(void)test_AFHTTPRequestOperation_usingResponder
+{
+    NSData* expectedResponse = [NSStringFromSelector(_cmd) dataUsingEncoding:NSUTF8StringEncoding];
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        OHHTTPStubsResponse *responseStub = [OHHTTPStubsResponse responseWithData:expectedResponse statusCode:200 responseTime:0 headers:nil];
+        responseStub.responder = ^(dispatch_block_t respondBlock)
+        {
+            [self notifyAsyncOperationDoneWithObject:respondBlock];
+        };
+        return responseStub;
+    }];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    AFHTTPRequestOperation* op = [[AFHTTPRequestOperation alloc] initWithRequest:req];
+    __block id response = nil;
+    [op setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        response = responseObject;
+        [self notifyAsyncOperationDone];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        STFail(@"Unexpected network failure");
+        [self notifyAsyncOperationDone];
+    }];
+    [op start];
+    
+    dispatch_block_t respondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(respondBlock, @"Expected respondBlock");
+    if (respondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        respondBlock();
+    }
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
     
     STAssertEqualObjects(response, expectedResponse, @"Unexpected data received");
 }

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLConnectionDelegateTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLConnectionDelegateTests.m
@@ -67,6 +67,7 @@ static const NSTimeInterval kResponseTimeTolerence = 0.2;
         if ([response isKindOfClass:[NSHTTPURLResponse class]])
         {
             _redirectResponseStatusCode = [((NSHTTPURLResponse *) response) statusCode];
+            [self notifyAsyncOperationDone];
         }
         else
         {
@@ -136,6 +137,47 @@ static const NSTimeInterval kResponseTimeTolerence = 0.2;
     [cxn cancel];
 }
 
+-(void)test_NSURLConnectionDelegate_success_usingResponder
+{
+    NSData* testData = [NSStringFromSelector(_cmd) dataUsingEncoding:NSUTF8StringEncoding];
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        OHHTTPStubsResponse *responseStub = [OHHTTPStubsResponse responseWithData:testData
+                                                                       statusCode:200
+                                                                     responseTime:0
+                                                                          headers:nil];
+        responseStub.responder = ^(dispatch_block_t respondBlock)
+        {
+            [self notifyAsyncOperationDoneWithObject:respondBlock];
+        };
+        return responseStub;
+    }];
+        
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    NSDate* startDate = [NSDate date];
+    
+    NSURLConnection* cxn = [NSURLConnection connectionWithRequest:req delegate:self];
+    
+    dispatch_block_t respondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(respondBlock, @"Expected respondBlock");
+    if (respondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        respondBlock();
+    }
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
+    
+    STAssertEqualObjects(_data, testData, @"Invalid data response");
+    STAssertNil(_error, @"Received unexpected network error %@", _error);
+    STAssertEqualsWithAccuracy(-[startDate timeIntervalSinceNow], (NSTimeInterval)0, kResponseTimeTolerence, @"Invalid response time");
+    
+    // in case we timed out before the end of the request (test failed), cancel the request to avoid further delegate method calls
+    [cxn cancel];
+}
+
 -(void)test_NSURLConnectionDelegate_error
 {
     static const NSTimeInterval kResponseTime = 1.0;
@@ -160,6 +202,46 @@ static const NSTimeInterval kResponseTimeTolerence = 0.2;
     STAssertEqualObjects(_error.domain, expectedError.domain, @"Invalid error response domain");
     STAssertEquals(_error.code, expectedError.code, @"Invalid error response code");
     STAssertEqualsWithAccuracy(-[startDate timeIntervalSinceNow], kResponseTime, kResponseTimeTolerence, @"Invalid response time");
+    
+    // in case we timed out before the end of the request (test failed), cancel the request to avoid further delegate method calls
+    [cxn cancel];
+}
+
+-(void)test_NSURLConnectionDelegate_error_usingResponder
+{
+    NSError* expectedError = [NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil];
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        OHHTTPStubsResponse* resp = [OHHTTPStubsResponse responseWithError:expectedError];
+        resp.responseTime = 0;
+        resp.responder = ^(dispatch_block_t respondBlock)
+        {
+            [self notifyAsyncOperationDoneWithObject:respondBlock];
+        };
+        return resp;
+    }];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    NSDate* startDate = [NSDate date];
+    
+    NSURLConnection* cxn = [NSURLConnection connectionWithRequest:req delegate:self];
+    
+    dispatch_block_t respondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(respondBlock, @"Expected respondBlock");
+    if (respondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        respondBlock();
+    }
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
+    
+    STAssertEquals(_data.length, 0U, @"Received unexpected network data %@", _data);
+    STAssertEqualObjects(_error.domain, expectedError.domain, @"Invalid error response domain");
+    STAssertEquals(_error.code, expectedError.code, @"Invalid error response code");
+    STAssertEqualsWithAccuracy(-[startDate timeIntervalSinceNow], (NSTimeInterval)0, kResponseTimeTolerence, @"Invalid response time");
     
     // in case we timed out before the end of the request (test failed), cancel the request to avoid further delegate method calls
     [cxn cancel];
@@ -195,9 +277,48 @@ static const NSTimeInterval kResponseTimeTolerence = 0.2;
     [cxn cancel];
 }
 
+-(void)test_NSURLConnection_cancel_usingResponder
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        OHHTTPStubsResponse *responseStub = [OHHTTPStubsResponse responseWithData:[@"<this data should never have time to arrive>" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                       statusCode:500
+                                                                     responseTime:0
+                                                                          headers:nil];
+        responseStub.responder = ^(dispatch_block_t respondBlock)
+        {
+            [self notifyAsyncOperationDoneWithObject:respondBlock];
+        };
+        return responseStub;
+    }];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    NSURLConnection* cxn = [NSURLConnection connectionWithRequest:req delegate:self];
+    
+    dispatch_block_t respondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(respondBlock, @"Expected respondBlock");
+    
+    [cxn cancel];
+    
+    if (respondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        respondBlock();
+    }
+    
+    [self waitForTimeout:1.5];
+    
+    STAssertEquals(_data.length, 0U, @"Received unexpected data but the request should have been cancelled");
+    STAssertNil(_error, @"Received unexpected network error but the request should have been cancelled");
+    
+    // in case we timed out before the end of the request (test failed), cancel the request to avoid further delegate method calls
+    [cxn cancel];
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////
-#pragma mark Cancelling requests
+#pragma mark Cookies
 ///////////////////////////////////////////////////////////////////////////////////
 
 -(void)test_NSURLConnection_cookies
@@ -299,13 +420,129 @@ static const NSTimeInterval kResponseTimeTolerence = 0.2;
     
     NSURLConnection* cxn = [NSURLConnection connectionWithRequest:req delegate:self];
     
-    [self waitForAsyncOperationWithTimeout:2 * (kResponseTime+kResponseTimeTolerence)];
+    [self waitForAsyncOperations:2 withTimeout:2 * (kResponseTime+kResponseTimeTolerence)];
     
     STAssertEqualObjects(_redirectRequestURL, endURL, @"Invalid redirect request URL");
     STAssertEquals(_redirectResponseStatusCode, 311, @"Invalid redirect response status code");
     STAssertEqualObjects(_data, testData, @"Invalid data response");
     STAssertNil(_error, @"Received unexpected network error %@", _error);
     STAssertEqualsWithAccuracy(-[startDate timeIntervalSinceNow], 2 * kResponseTime, 2 * kResponseTimeTolerence, @"Invalid response time");
+    
+    /* Check that the redirect cookie has been properly stored */
+    NSArray* redirectCookies = [cookieStorage cookiesForURL:req.URL];
+    BOOL redirectCookieFound = NO;
+    for (NSHTTPCookie* cookie in redirectCookies)
+    {
+        if ([cookie.name isEqualToString:redirectCookieName])
+        {
+            redirectCookieFound = YES;
+            STAssertEqualObjects(cookie.value, redirectCookieValue, @"The redirect cookie does not have the expected value");
+        }
+    }
+    STAssertTrue(redirectCookieFound, @"The redirect cookie was not stored as expected");
+    
+    /* Check that the end cookie has been properly stored */
+    NSArray* endCookies = [cookieStorage cookiesForURL:endURL];
+    BOOL endCookieFound = NO;
+    for (NSHTTPCookie* cookie in endCookies)
+    {
+        if ([cookie.name isEqualToString:endCookieName])
+        {
+            endCookieFound = YES;
+            STAssertEqualObjects(cookie.value, endCookieValue, @"The end cookie does not have the expected value");
+        }
+    }
+    STAssertTrue(endCookieFound, @"The end cookie was not stored as expected");
+    
+    // in case we timed out before the end of the request (test failed), cancel the request to avoid further delegate method calls
+    [cxn cancel];
+    
+    
+    // As a courtesy, restore previous policy before leaving
+    [cookieStorage setCookieAcceptPolicy:previousAcceptPolicy];
+}
+
+- (void)test_NSURLConnection_redirected_usingResponder
+{
+    NSData* redirectData = [[NSString stringWithFormat:@"%@ - redirect", NSStringFromSelector(_cmd)] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData* testData = [NSStringFromSelector(_cmd) dataUsingEncoding:NSUTF8StringEncoding];
+    NSURL* redirectURL = [NSURL URLWithString:@"http://www.yahoo.com/"];
+    NSString* redirectCookieName = @"yahooCookie";
+    NSString* redirectCookieValue = [[NSProcessInfo processInfo] globallyUniqueString];
+    
+    // Set the cookie accept policy to accept all cookies from the main document domain
+    // (especially in case the previous policy was "NSHTTPCookieAcceptPolicyNever")
+    NSHTTPCookieStorage* cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    NSHTTPCookieAcceptPolicy previousAcceptPolicy = [cookieStorage cookieAcceptPolicy]; // keep it to restore later
+    [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain];
+    
+    NSString* endCookieName = @"googleCookie";
+    NSString* endCookieValue = [[NSProcessInfo processInfo] globallyUniqueString];
+    NSURL *endURL = [NSURL URLWithString:@"http://www.google.com/"];
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        if ([[request URL] isEqual:redirectURL]) {
+            NSString* redirectCookie = [NSString stringWithFormat:@"%@=%@;", redirectCookieName, redirectCookieValue];
+            NSDictionary* headers = [NSDictionary dictionaryWithObjectsAndKeys:
+                                     [endURL absoluteString], @"Location",
+                                     redirectCookie, @"Set-Cookie",
+                                     nil];
+            OHHTTPStubsResponse *responseStub = [OHHTTPStubsResponse responseWithData:redirectData
+                                                                           statusCode:311 // any 300-level request will do
+                                                                         responseTime:0
+                                                                              headers:headers];
+            responseStub.responder = ^(dispatch_block_t respondBlock)
+            {
+                [self notifyAsyncOperationDoneWithObject:respondBlock];
+            };
+            return responseStub;
+        } else {
+            NSString* endCookie = [NSString stringWithFormat:@"%@=%@;", endCookieName, endCookieValue];
+            NSDictionary* headers = [NSDictionary dictionaryWithObject:endCookie forKey:@"Set-Cookie"];
+            OHHTTPStubsResponse *responseStub =  [OHHTTPStubsResponse responseWithData:testData
+                                                                            statusCode:200
+                                                                          responseTime:0
+                                                                               headers:headers];
+            responseStub.responder = ^(dispatch_block_t respondBlock)
+            {
+                [self notifyAsyncOperationDoneWithObject:respondBlock];
+            };
+            return responseStub;
+        }
+    }];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:redirectURL];
+    NSDate* startDate = [NSDate date];
+    
+    NSURLConnection* cxn = [NSURLConnection connectionWithRequest:req delegate:self];
+    
+    dispatch_block_t redirectRespondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(redirectRespondBlock, @"Expected respondBlock");
+    if (redirectRespondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        redirectRespondBlock();
+    }
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
+    
+    dispatch_block_t endRespondBlock = [self waitForAsyncOperationObjectWithTimeout:kResponseTimeTolerence];
+    STAssertNotNil(endRespondBlock, @"Expected respondBlock");
+    if (endRespondBlock)
+    {
+        // STAssertNotNil doesn't stop execution, so guard against crashes
+        endRespondBlock();
+    }
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
+    
+    STAssertEqualObjects(_redirectRequestURL, endURL, @"Invalid redirect request URL");
+    STAssertEquals(_redirectResponseStatusCode, 311, @"Invalid redirect response status code");
+    STAssertEqualObjects(_data, testData, @"Invalid data response");
+    STAssertNil(_error, @"Received unexpected network error %@", _error);
+    STAssertEqualsWithAccuracy(-[startDate timeIntervalSinceNow], (NSTimeInterval)0, 4 * kResponseTimeTolerence, @"Invalid response time");
     
     /* Check that the redirect cookie has been properly stored */
     NSArray* redirectCookies = [cookieStorage cookiesForURL:req.URL];


### PR DESCRIPTION
Instead of relying on a timeout, users can now execute responses arbitrarily. An OHHTTPStubsResponse has a responder block, which if populated is called with a dispatch_block_t, which can be called from anywhere to cause processing to continue. This makes ordered operations much easier to guarantee, and will make tests execute faster.
