### PR TITLE
Add convenience JSON/NSDictionary factory method to OHHTTPStubsResponse

### DIFF
--- a/OHHTTPStubs/OHHTTPStubsResponse.h
+++ b/OHHTTPStubs/OHHTTPStubsResponse.h
@@ -127,6 +127,23 @@ OHHTTPStubsDownloadSpeedWifi;
  */
 +(instancetype)responseWithError:(NSError*)error;
 
+/**
+ * Builds a response given a JSON object for the response body, status code, and headers.
+ *
+ * @param jsonObject object representing the response body.
+ *            Typically a `NSDictionary`; may be any object accepted by +[NSJSONSerialization dataWithJSONObject:options:error:]
+ * @param statusCode the HTTP statuc doe to use in the response
+ * @param responseTime the time to wait before the response is sent
+ * @param httpHeaders The HTTP headers to return in the response. 
+ *            If a Content-Type header is not included, "Content-Type: application/json" will be added.
+ *
+ * @return an OHHTTPStubsResponse describing the corresponding response to return by the stub
+ */
++ (instancetype)responseWithJSONObject:(id)jsonObject
+                            statusCode:(int)statusCode
+                          responseTime:(NSTimeInterval)responseTime
+                               headers:(NSDictionary*)httpHeaders;
+
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Instance Methods
 

--- a/OHHTTPStubs/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/OHHTTPStubsResponse.m
@@ -160,5 +160,23 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     return response;
 }
 
++ (instancetype)responseWithJSONObject:(id)jsonObject
+                            statusCode:(int)statusCode
+                          responseTime:(NSTimeInterval)responseTime
+                               headers:(NSDictionary *)httpHeaders
+{
+    if (!httpHeaders[@"Content-Type"]) {
+        NSMutableDictionary *mutableHeaders = [httpHeaders mutableCopy];
+        mutableHeaders[@"Content-Type"] = @"application/json";
+        httpHeaders = mutableHeaders;
+    }
+
+    return [self responseWithData:[NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:nil]
+                       statusCode:statusCode
+                     responseTime:responseTime
+                          headers:httpHeaders
+            ];
+}
+
 
 @end


### PR DESCRIPTION
This new method `responseWithJsonObject:statusCode:responseTime:headers:` allows easy construction of JSON-based stub responses.

It accepts an NSDictionary, or anything accepted by `+[NSJSONSerialization dataWithJSONObject:options:error:]`, and returns that object as JSON in the response body.

This makes ad-hoc definition of lightweight responses inside unit tests simple and easy.
