### PR TITLE
Bad access when request URL is nil and cookie handling is enabled for iOS 6.1 and below

### DIFF
--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -67,4 +67,44 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
 }
 
+- (void)_test_NilURLAndCookieHandlingEnabled:(BOOL)handleCookiesEnabled
+{
+    NSData* expectedResponse = [NSStringFromSelector(_cmd) dataUsingEncoding:NSUTF8StringEncoding];
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithData:expectedResponse
+                                          statusCode:200
+                                             headers:nil];
+    }];
+    
+    NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:nil];
+    [req setHTTPShouldHandleCookies:handleCookiesEnabled];
+    
+    __block NSData* response = nil;
+    
+    [NSURLConnection sendAsynchronousRequest:req
+                                       queue:[NSOperationQueue mainQueue]
+                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
+     {
+         response = data;
+         [self notifyAsyncOperationDone];
+     }];
+    
+    [self waitForAsyncOperationWithTimeout:kResponseTimeTolerence];
+    
+    STAssertEqualObjects(response, expectedResponse, @"Unexpected data received");
+}
+
+- (void)test_NilURLAndCookieHandlingEnabled
+{
+    [self _test_NilURLAndCookieHandlingEnabled:YES];
+}
+
+- (void)test_NilURLAndCookieHandlingDisabled
+{
+    [self _test_NilURLAndCookieHandlingEnabled:NO];
+}
+
 @end


### PR DESCRIPTION
Write unit tests in order to show a bad access issue on iOS 6.1 and below, when cookies are enabled and URL is nil on a request.
