### PR TITLE
README suggests `pod install` instead of `update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ _As far as I know, there's nothing we can do about those two limitations. Please
 
 ## Installing in your projects
 
-[CocoaPods](http://cocoapods.org/) is the easiest way to add third-party libraries like `OHHTTPStubs` in your projects. Simply add `pod 'OHHTTPStubs'` to your `Podfile` then run `pod update` and you are ready to use it.
+[CocoaPods](http://cocoapods.org/) is the easiest way to add third-party libraries like `OHHTTPStubs` in your projects. Simply add `pod 'OHHTTPStubs'` to your `Podfile` then run `pod install` and you are ready to use it.
 
 _Note: `OHHTTPStubs` needs iOS5 minimum._
 


### PR DESCRIPTION
`pod update` will also update all the other installed Pods to their latest version, potentially breaking things. `pod install` will just add the new pod.

(Not a huge deal, just seemed like a safer choice)
