### PR TITLE
Fixed crash when stub with very long data and no delay for response

### DIFF
--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -469,7 +469,7 @@ typedef struct {
                                timingInfo:timingInfo completion:completion];
             });
         } else {
-            uint8_t buffer[chunkSizeToRead];
+            uint8_t* buffer = (uint8_t*)malloc(sizeof(uint8_t*)*chunkSizeToRead);
             NSInteger bytesRead = [inputStream read:buffer maxLength:chunkSizeToRead];
             if (bytesRead > 0)
             {

--- a/OHHTTPStubs/UnitTests/Test Suites/TimingTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/TimingTests.m
@@ -126,4 +126,16 @@ static NSTimeInterval const kSecurityTimeout = 5.0;
     [self _testWithData:testData requestTime:1 responseTime:5];
 }
 
+-(void)test_VeryLongData_RequestTime1_ResponseTime0
+{
+    static NSUInteger const kDataLength = 609792;
+    NSMutableData* testData = [NSMutableData dataWithCapacity:kDataLength];
+    NSData* chunk = [[NSProcessInfo.processInfo globallyUniqueString] dataUsingEncoding:NSUTF8StringEncoding];
+    while(testData.length<kDataLength)
+    {
+        [testData appendData:chunk];
+    }
+    [self _testWithData:testData requestTime:1 responseTime:0];
+}
+
 @end


### PR DESCRIPTION
Salut Olivier,

J'ai rencontré un crash en voulant faire un stub avec un gros fichier (environ 610ko).

Du coup j'ai corrigé la ligne ou le crash avait lieu : j'ai simplement utilisé un malloc plutôt qu'une allocation statique pour le buffer.

Je n'ai pas compris exactement pourquoi l'allocation statique faisait craché une ligne plus loin et encore moins pourquoi ça crash quand responseTime vaut 0s et pas quand responseTime vaut 5s.

Je t'ai rajouté un test case pour que tu puisses troubleshooter ça.

Bon weekend !
