### PR TITLE
Handle HTTP status code 300 differently than other redirect codes.

### DIFF
--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -362,7 +362,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
         {
             redirectLocationURL = nil;
         }
-        if (((responseStub.statusCode >= 300) && (responseStub.statusCode < 400)) && redirectLocationURL)
+        if (((responseStub.statusCode > 300) && (responseStub.statusCode < 400)) && redirectLocationURL)
         {
             NSURLRequest* redirectRequest = [NSURLRequest requestWithURL:redirectLocationURL];
             execute_after(responseStub.requestTime, ^{


### PR DESCRIPTION
Treats status code 300 'multiple choices' like a 2xx code to give the user agent a chance to select the redirect url.

Relates to issue #91 