### PR TITLE
Stub network requests easily with Mocktail files/folders

### DIFF
--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
@@ -29,13 +29,14 @@ extern NSString* const MocktailErrorDomain;
  * This method will split the HTTP method Regex, the absolute URL Regex, the headers, the HTTP status code and
  * response body, and use them to add a stub.
  *
- * @param fileName The name of the `"*.tail"` file (with extension) in the Mocktail format.
+ * @param fileName The name of the mocktail file (without extension of '.tail') in the Mocktail format.
+ * @param bundleOrNil The bundle in which the mocktail file is located. If `nil`, the `[NSBundle bundleForClass:self.class]` will be used.
  * @param error An out value that returns any error encountered during stubbing. Returns an NSError object if any error; otherwise returns nil.
  *
  * @return a stub descriptor that uniquely identifies the stub and can be later used to remove it with
  * `removeStub:`.
  */
-+(id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName error:(NSError **)error;
++(id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
 
 /**
  * Add a stub given a file URL in the format of Mocktail as defined at https://github.com/square/objc-mocktail.
@@ -57,12 +58,13 @@ extern NSString* const MocktailErrorDomain;
  * This method will retrieve all the files under the folder; for each file with surfix of ".tail", it will split the HTTP method Regex, the absolute URL Regex, the headers, the HTTP status code and response body, and use them to add a stub.
  *
  * @param path The name of the folder containing files in the Mocktail format.
+ * @param bundleOrNil The bundle in which the path is located. If `nil`, the `[NSBundle bundleForClass:self.class]` will be used.
  * @param error An out value that returns any error encountered during stubbing. Returns an NSError object if any error; otherwise returns nil.
  *
  * @return an array of stub descriptor that uniquely identifies the stub and can be later used to remove it with
  * `removeStub:`.
  */
-+(NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path error:(NSError **)error;
++(NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
 
 @end
 

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -33,7 +33,8 @@
 - (void)testMoctTailLoginSuccess
 {
     NSError *error = nil;
-    [OHHTTPStubs stubRequestsUsingMocktailNamed:@"login.tail" error: &error];
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    [OHHTTPStubs stubRequestsUsingMocktailNamed:@"login" inBundle:bundle error: &error];
     XCTAssertNil(error, @"Error while stubbing 'login.tail':%@", [error localizedDescription]);
     [self runLogin];
 }
@@ -41,7 +42,8 @@
 - (void)testMocktailsAtFolder
 {
     NSError *error = nil;
-    [OHHTTPStubs stubRequestsUsingMocktailsAtPath:@"MocktailFolder" error:&error];
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    [OHHTTPStubs stubRequestsUsingMocktailsAtPath:@"MocktailFolder" inBundle:bundle error:&error];
     XCTAssertNil(error, @"Error while stubbing Mocktails at folder 'MocktailFolder': %@", [error localizedDescription]);
     [self runLogin];
     [self runGetCards];


### PR DESCRIPTION
This is an effort to support stubbing the network requests using files in the format of Mocktail(see more at: https://github.com/square/objc-mocktail). Mocktail is a popular format of network mocking which contains every piece of information in order to mock/stub a network request. By supporting this format, first, we will be able to allow Mocktail users to convert to OHHTTPStatus; Secondly, we will be able to add other functionalities to OHHTTPStatus, for example, recording traffic in the format of Mocktail and later on use it for stubbing. 