### PR TITLE
[OHHTTPStubs] Resolved circular dependency when using dynamic framework

### DIFF
--- a/OHHTTPStubs/Sources/OHHTTPStubs.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.h
@@ -29,8 +29,8 @@
 #import <Foundation/Foundation.h>
 
 #import <OHHTTPStubs/Compatibility.h>
-#import <OHHTTPStubs/OHHTTPStubsResponse.h>
 
+@class OHHTTPStubsResponse;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -30,6 +30,7 @@
 #pragma mark - Imports
 
 #import <OHHTTPStubs/OHHTTPStubs.h>
+#import <OHHTTPStubs/OHHTTPStubsResponse.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Types & Constants


### PR DESCRIPTION
Moved import of OHHTTPStubsResponse from .h to .m to resolving circular dependencies when using dynamic framework.