### PR TITLE
Add methods to create `OHHTPStubResponse`s from `NSURL`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OHHTTPStubs — CHANGELOG
 
+## [4.4.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/4.4.0)
+
+* Added two methods for creating `OHHTTPStubsResponse`s from `NSURL`s that represent file system resources ([@MaxGabriel](https://github.com/MaxGabriel), [#129](https://github.com/AliSoftware/OHHTTPStubs/pull/129))
+
 ## [4.3.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/4.3.0)
 
 * Xcode projects updated to Xcode 7.0 Final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.4.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/4.4.0)
 
-* Added two methods for creating `OHHTTPStubsResponse`s from `NSURL`s that represent file system resources ([@MaxGabriel](https://github.com/MaxGabriel), [#129](https://github.com/AliSoftware/OHHTTPStubs/pull/129))
+* Added methods for creating `OHHTTPStubsResponse`s from `NSURL`s that represent file system resources ([@MaxGabriel](https://github.com/MaxGabriel), [#129](https://github.com/AliSoftware/OHHTTPStubs/pull/129))
 
 ## [4.3.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/4.3.0)
 

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.h
@@ -138,6 +138,22 @@ NS_ASSUME_NONNULL_BEGIN
                            statusCode:(int)statusCode
                               headers:(nullable NSDictionary*)httpHeaders;
 
+
+/**
+ *  Builds a response given a URL, the status code, and headers.
+ *
+ *  @param url         The URL for the data to reutrn in the response
+ *  @param statusCode  The HTTP Status Code to use in the response
+ *  @param httpHeaders The HTTP Headers to return in the response
+ *
+ *  @return An `OHHTTPStubsResponse` describing the corresponding response to return by the stub
+ *
+ *  @note This method applies only to URLs that represent file system resources
+ */
++(instancetype)responseWithURL:(NSURL *)url
+                    statusCode:(int)statusCode
+                       headers:(nullable NSDictionary *)httpHeaders;
+
 /* -------------------------------------------------------------------------- */
 #pragma mark > Building an error response
 
@@ -238,6 +254,21 @@ NS_ASSUME_NONNULL_BEGIN
                        statusCode:(int)statusCode
                           headers:(nullable NSDictionary*)httpHeaders;
 
+
+/**
+ *  Initialize a response with a given URL, statusCode and headers.
+ *
+ *  @param url         The URL for the data to reutrn in the response
+ *  @param statusCode  The HTTP Status Code to use in the response
+ *  @param httpHeaders The HTTP Headers to return in the response
+ *
+ *  @return An `OHHTTPStubsResponse` describing the corresponding response to return by the stub
+ *
+ *  @note This method applies only to URLs that represent file system resources
+ */
+-(instancetype)initWithURL:(NSURL *)url
+                statusCode:(int)statusCode
+                   headers:(nullable NSDictionary *)httpHeaders;
 
 /**
  *  Initialize a response with the given data, statusCode and headers.

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.h
@@ -142,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Builds a response given a URL, the status code, and headers.
  *
- *  @param url         The URL for the data to reutrn in the response
+ *  @param fileURL     The URL for the data to return in the response
  *  @param statusCode  The HTTP Status Code to use in the response
  *  @param httpHeaders The HTTP Headers to return in the response
  *
@@ -150,9 +150,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @note This method applies only to URLs that represent file system resources
  */
-+(instancetype)responseWithURL:(NSURL *)url
-                    statusCode:(int)statusCode
-                       headers:(nullable NSDictionary *)httpHeaders;
++(instancetype)responseWithFileURL:(NSURL *)fileURL
+                        statusCode:(int)statusCode
+                           headers:(nullable NSDictionary *)httpHeaders;
 
 /* -------------------------------------------------------------------------- */
 #pragma mark > Building an error response
@@ -258,7 +258,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Initialize a response with a given URL, statusCode and headers.
  *
- *  @param url         The URL for the data to reutrn in the response
+ *  @param fileURL     The URL for the data to return in the response
  *  @param statusCode  The HTTP Status Code to use in the response
  *  @param httpHeaders The HTTP Headers to return in the response
  *
@@ -266,9 +266,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @note This method applies only to URLs that represent file system resources
  */
--(instancetype)initWithURL:(NSURL *)url
-                statusCode:(int)statusCode
-                   headers:(nullable NSDictionary *)httpHeaders;
+-(instancetype)initWithFileURL:(NSURL *)fileURL
+                    statusCode:(int)statusCode
+                       headers:(nullable NSDictionary *)httpHeaders;
 
 /**
  *  Initialize a response with the given data, statusCode and headers.

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -157,7 +157,7 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     NSInputStream* inputStream;
     if (fileURL)
     {
-        NSAssert(fileURL.fileURL, @"Only file URLs may be passed to %@", NSStringFromSelector(_cmd));
+        NSAssert(fileURL.isFileURL, @"Only file URLs may be passed to %@", NSStringFromSelector(_cmd));
         inputStream = [NSInputStream inputStreamWithURL:fileURL];
     }
     else

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -75,6 +75,15 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     return response;
 }
 
++(instancetype)responseWithURL:(NSURL *)url
+                    statusCode:(int)statusCode
+                       headers:(nullable NSDictionary *)httpHeaders
+{
+    OHHTTPStubsResponse* response = [[self alloc] initWithURL:url
+                                                   statusCode:statusCode
+                                                      headers:httpHeaders];
+    return response;
+}
 
 #pragma mark > Building an error response
 
@@ -152,6 +161,37 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
                             dataSize:fileSize
                           statusCode:statusCode
                              headers:httpHeaders];
+    return self;
+}
+
+-(instancetype)initWithURL:(NSURL *)url
+                statusCode:(int)statusCode
+                   headers:(nullable NSDictionary *)httpHeaders {
+    NSInputStream* inputStream;
+    if (url)
+    {
+        inputStream = [NSInputStream inputStreamWithURL:url];
+    }
+    else
+    {
+        NSLog(@"%s: nil URL. Returning empty data", __PRETTY_FUNCTION__);
+        inputStream = [NSInputStream inputStreamWithData:[NSData data]];
+    }
+    
+    NSError *error;
+    NSNumber *fileSize;
+    [url getResourceValue:&fileSize forKey:NSURLFileSizeKey error:&error];
+    
+    if (error) {
+        NSLog(@"%s: Error getting file size for URL. Returning empty data", __PRETTY_FUNCTION__);
+        inputStream = [NSInputStream inputStreamWithData:[NSData data]];
+    } else {
+        self = [self initWithInputStream:inputStream
+                                dataSize:[fileSize unsignedLongLongValue]
+                              statusCode:statusCode
+                                 headers:httpHeaders];
+    }
+    
     return self;
 }
 

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -75,13 +75,13 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     return response;
 }
 
-+(instancetype)responseWithURL:(NSURL *)url
-                    statusCode:(int)statusCode
-                       headers:(nullable NSDictionary *)httpHeaders
++(instancetype)responseWithFileURL:(NSURL *)fileURL
+                        statusCode:(int)statusCode
+                           headers:(nullable NSDictionary *)httpHeaders
 {
-    OHHTTPStubsResponse* response = [[self alloc] initWithURL:url
-                                                   statusCode:statusCode
-                                                      headers:httpHeaders];
+    OHHTTPStubsResponse* response = [[self alloc] initWithFileURL:fileURL
+                                                       statusCode:statusCode
+                                                          headers:httpHeaders];
     return response;
 }
 
@@ -164,13 +164,13 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     return self;
 }
 
--(instancetype)initWithURL:(NSURL *)url
-                statusCode:(int)statusCode
-                   headers:(nullable NSDictionary *)httpHeaders {
+-(instancetype)initWithFileURL:(NSURL *)fileURL
+                    statusCode:(int)statusCode
+                       headers:(nullable NSDictionary *)httpHeaders {
     NSInputStream* inputStream;
-    if (url)
+    if (fileURL)
     {
-        inputStream = [NSInputStream inputStreamWithURL:url];
+        inputStream = [NSInputStream inputStreamWithURL:fileURL];
     }
     else
     {
@@ -180,7 +180,7 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     
     NSError *error;
     NSNumber *fileSize;
-    [url getResourceValue:&fileSize forKey:NSURLFileSizeKey error:&error];
+    [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:&error];
     
     if (error) {
         NSLog(@"%s: Error getting file size for URL. Returning empty data", __PRETTY_FUNCTION__);

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -144,23 +144,10 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
                        statusCode:(int)statusCode
                           headers:(nullable NSDictionary*)httpHeaders
 {
-    NSInputStream* inputStream;
-    if (filePath)
-    {
-        inputStream = [NSInputStream inputStreamWithFileAtPath:filePath];
-    }
-    else
-    {
-        NSLog(@"%s: nil file path. Returning empty data", __PRETTY_FUNCTION__);
-        inputStream = [NSInputStream inputStreamWithData:[NSData data]];
-    }
-    
-    NSDictionary* attributes = [NSFileManager.defaultManager attributesOfItemAtPath:filePath error:nil];
-    unsigned long long fileSize = [[attributes valueForKey:NSFileSize] unsignedLongLongValue];
-    self = [self initWithInputStream:inputStream
-                            dataSize:fileSize
-                          statusCode:statusCode
-                             headers:httpHeaders];
+    NSURL *fileURL = filePath ? [NSURL fileURLWithPath:filePath] : nil;
+    self = [self initWithFileURL:fileURL
+                      statusCode:statusCode
+                         headers:httpHeaders];
     return self;
 }
 

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -157,7 +157,12 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     NSInputStream* inputStream;
     if (fileURL)
     {
-        NSAssert(fileURL.isFileURL, @"Only file URLs may be passed to %@", NSStringFromSelector(_cmd));
+        // [NSURL -isFileURL] is only available on iOS 8+
+        if (![fileURL.scheme isEqualToString:NSURLFileScheme]) {
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                           reason:[NSString stringWithFormat:@"Only file URLs may be passed to %@", NSStringFromSelector(_cmd)]
+                                         userInfo:nil];
+        }
         inputStream = [NSInputStream inputStreamWithURL:fileURL];
     }
     else

--- a/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubsResponse.m
@@ -157,6 +157,7 @@ const double OHHTTPStubsDownloadSpeedWifi   =- 12000 / 8; // kbps -> KB/s
     NSInputStream* inputStream;
     if (fileURL)
     {
+        NSAssert(fileURL.fileURL, @"Only file URLs may be passed to %@", NSStringFromSelector(_cmd));
         inputStream = [NSInputStream inputStreamWithURL:fileURL];
     }
     else

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -147,54 +147,14 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
 
 - (void)test_InvalidPath
 {
-    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-        return YES;
-    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        return [[OHHTTPStubsResponse responseWithFileAtPath:@"-invalid-path-" statusCode:500 headers:nil]
-        requestTime:0.01 responseTime:0.01];
-    }];
-    
-    XCTestExpectation* expectation = [self expectationWithDescription:@"Network request's completionHandler called"];
-    
-    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
-    
-    [NSURLConnection sendAsynchronousRequest:req
-                                       queue:[NSOperationQueue mainQueue]
-                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
-     {
-         XCTAssertEqual(data.length, (NSUInteger)0, @"Data should be empty");
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileAtPath:@"foo/bar" statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }
 
 - (void)test_InvalidPathWithURL
 {
-    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-        return YES;
-    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        NSURL *url = [NSURL URLWithString:@"file://foo/bar"];
-        NSAssert(url , @"If the URL is nil, this test is just duplicating test_NilPathWithURL");
-        return [[OHHTTPStubsResponse responseWithFileURL:url statusCode:501 headers:nil]
-                requestTime:0.01 responseTime:0.01];
-    }];
-    
-    XCTestExpectation* expectation = [self expectationWithDescription:@"Network request's completionHandler called"];
-    
-    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
-    
-    [NSURLConnection sendAsynchronousRequest:req
-                                       queue:[NSOperationQueue mainQueue]
-                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
-     {
-         XCTAssertEqual(data.length, (NSUInteger)0, @"Data should be empty");
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
+    NSURL *httpURL = [NSURL fileURLWithPath:@"foo/bar"];
+    NSAssert(httpURL, @"If the URL is nil an empty response is sent instead of an exception being thrown");
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }
 
 - (void)test_NonFileURL

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -175,7 +175,9 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return YES;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        return [[OHHTTPStubsResponse responseWithFileURL:[NSURL URLWithString:@"-invalid-url"] statusCode:501 headers:nil]
+        NSURL *url = [NSURL URLWithString:@"file://foo/bar"];
+        NSAssert(url , @"If the URL is nil, this test is just duplicating test_NilPathWithURL");
+        return [[OHHTTPStubsResponse responseWithFileURL:url statusCode:501 headers:nil]
                 requestTime:0.01 responseTime:0.01];
     }];
     

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -147,21 +147,24 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
 
 - (void)test_InvalidPath
 {
-    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileAtPath:@"foo/bar" statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileAtPath:@"foo/bar" statusCode:501 headers:nil]
+                                 , NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }
 
 - (void)test_InvalidPathWithURL
 {
     NSURL *httpURL = [NSURL fileURLWithPath:@"foo/bar"];
     NSAssert(httpURL, @"If the URL is nil an empty response is sent instead of an exception being thrown");
-    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil]
+                                 , NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }
 
 - (void)test_NonFileURL
 {
     NSURL *httpURL = [NSURL URLWithString:@"http://www.iana.org/domains/example/"];
     NSAssert(httpURL, @"If the URL is nil an empty response is sent instead of an exception being thrown");
-    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil]
+                                 , NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }
 
 

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -124,7 +124,7 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-        return [[OHHTTPStubsResponse responseWithURL:nil statusCode:501 headers:nil]
+        return [[OHHTTPStubsResponse responseWithFileURL:nil statusCode:501 headers:nil]
                 requestTime:0.01 responseTime:0.01];
 #pragma clang diagnostic pop
     }];
@@ -175,7 +175,7 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return YES;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        return [[OHHTTPStubsResponse responseWithURL:[NSURL URLWithString:@"-invalid-url"] statusCode:501 headers:nil]
+        return [[OHHTTPStubsResponse responseWithFileURL:[NSURL URLWithString:@"-invalid-url"] statusCode:501 headers:nil]
                 requestTime:0.01 responseTime:0.01];
     }];
     
@@ -227,8 +227,8 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return YES;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        NSURL *url = [[NSBundle bundleForClass:[self class]] URLForResource:@"emptyfile" withExtension:@"json"];
-        return [[OHHTTPStubsResponse responseWithURL:url statusCode:500 headers:nil]
+        NSURL *fileURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"emptyfile" withExtension:@"json"];
+        return [[OHHTTPStubsResponse responseWithFileURL:fileURL statusCode:500 headers:nil]
                 requestTime:0.01 responseTime:0.01];
     }];
     

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -199,7 +199,7 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
 
 - (void)test_NonFileURL
 {
-    NSURL *httpURL = [NSURL URLWithString:@"http://example.com"];
+    NSURL *httpURL = [NSURL URLWithString:@"http://www.iana.org/domains/example/"];
     NSAssert(httpURL, @"If the URL is nil an empty response is sent instead of an exception being thrown");
     XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
 }

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -197,6 +197,13 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
 }
 
+- (void)test_NonFileURL
+{
+    NSURL *httpURL = [NSURL URLWithString:@"http://example.com"];
+    NSAssert(httpURL, @"If the URL is nil an empty response is sent instead of an exception being thrown");
+    XCTAssertThrowsSpecificNamed([OHHTTPStubsResponse responseWithFileURL:httpURL statusCode:501 headers:nil], NSException, NSInternalInconsistencyException, @"An exception should be thrown if a non-file URL is given");
+}
+
 
 - (void)test_EmptyFile
 {

--- a/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NilValuesTests.m
@@ -117,6 +117,34 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
 }
 
+- (void)test_NilPathWithURL
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+        return [[OHHTTPStubsResponse responseWithURL:nil statusCode:501 headers:nil]
+                requestTime:0.01 responseTime:0.01];
+#pragma clang diagnostic pop
+    }];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Network request's completionHandler called"];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    
+    [NSURLConnection sendAsynchronousRequest:req
+                                       queue:[NSOperationQueue mainQueue]
+                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
+     {
+         XCTAssertEqual(data.length, (NSUInteger)0, @"Data should be empty");
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
+}
+
 - (void)test_InvalidPath
 {
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -142,6 +170,32 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
 }
 
+- (void)test_InvalidPathWithURL
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [[OHHTTPStubsResponse responseWithURL:[NSURL URLWithString:@"-invalid-url"] statusCode:501 headers:nil]
+                requestTime:0.01 responseTime:0.01];
+    }];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Network request's completionHandler called"];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    
+    [NSURLConnection sendAsynchronousRequest:req
+                                       queue:[NSOperationQueue mainQueue]
+                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
+     {
+         XCTAssertEqual(data.length, (NSUInteger)0, @"Data should be empty");
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
+}
+
+
 - (void)test_EmptyFile
 {
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -149,6 +203,32 @@ static const NSTimeInterval kResponseTimeTolerence = 0.3;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
         NSString* emptyFile = OHPathForFile(@"emptyfile.json", self.class);
         return [[OHHTTPStubsResponse responseWithFileAtPath:emptyFile statusCode:500 headers:nil]
+                requestTime:0.01 responseTime:0.01];
+    }];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Network request's completionHandler called"];
+    
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+    
+    [NSURLConnection sendAsynchronousRequest:req
+                                       queue:[NSOperationQueue mainQueue]
+                           completionHandler:^(NSURLResponse* resp, NSData* data, NSError* error)
+     {
+         XCTAssertEqual(data.length, (NSUInteger)0, @"Data should be empty");
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:kResponseTimeTolerence handler:nil];
+}
+
+- (void)test_EmptyFileWithURL
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return YES;
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        NSURL *url = [[NSBundle bundleForClass:[self class]] URLForResource:@"emptyfile" withExtension:@"json"];
+        return [[OHHTTPStubsResponse responseWithURL:url statusCode:500 headers:nil]
                 requestTime:0.01 responseTime:0.01];
     }];
     

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ def build(scheme, sdk, destination, action)
     -workspace OHHTTPStubs/OHHTTPStubs.xcworkspace
     -scheme "#{scheme}"
     -sdk #{sdk}
-    -configuration Release
+    -configuration Debug
     ONLY_ACTIVE_ARCH=NO
     -destination '#{destination}'
     clean #{action}


### PR DESCRIPTION
iOS 4 allowed using `NSURL`s instead of `NSString`s for file paths. This PR allows using `NSURL`s to create `OHHTPStubResponse`s, which provides better compatibility with test code already using `NSURL`s.

I copied each test using `responseWithFileAtPath:statusCode:headers:` and used `responseWithURL:statusCode:headers:` there instead. This ends up duplicating a lot of code, but I know some people prefer that for tests, and this seemed in line with the existing tests.

An alternate implementation of this PR could be to implement the `NSURL` methods in terms of `NSString` based file paths, or vice versa.