### PR TITLE
Use SVG for the Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OHHTTPStubs
 [![Platform](http://cocoapod-badges.herokuapp.com/p/OHHTTPStubs/badge.png)](http://cocoadocs.org/docsets/OHHTTPStubs)
 [![Version](http://cocoapod-badges.herokuapp.com/v/OHHTTPStubs/badge.png)](http://cocoadocs.org/docsets/OHHTTPStubs)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Build Status](https://travis-ci.org/AliSoftware/OHHTTPStubs.png?branch=master)](https://travis-ci.org/AliSoftware/OHHTTPStubs)
+[![Build Status](https://travis-ci.org/AliSoftware/OHHTTPStubs.svg?branch=master)](https://travis-ci.org/AliSoftware/OHHTTPStubs)
 
 `OHHTTPStubs` is a library designed to stub your network requests very easily. It can help you:
 


### PR DESCRIPTION
If you look at the [rich diff](https://github.com/AliSoftware/OHHTTPStubs/pull/130/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8) it looks much better, and matches the other icons.