### PR TITLE
Use explicit CFBundleVersion number

### DIFF
--- a/OHHTTPStubs/Supporting Files/OHHTTPStubs iOS-Info.plist
+++ b/OHHTTPStubs/Supporting Files/OHHTTPStubs iOS-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
When building OHHTTPStubs using Carthage the version number ended up being empty. This caused an issue when uploading my app to iTunes Connect:

`ERROR ITMS-90056: This bundle is invalid. The Info.plist file is missing the required key: CFBundleVersion`

Hard-coding the version resolved the issue for me. The file `OHHTTPStubs Mac-Info.plist` already has the CFBundleVersion set to '1'.