### PR TITLE
add `nullable` specifier to block that can be nil

### DIFF
--- a/OHHTTPStubs/Sources/OHHTTPStubs.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.h
@@ -169,7 +169,7 @@ typedef OHHTTPStubsResponse* __nonnull (^OHHTTPStubsResponseBlock)( NSURLRequest
  *  @param block The block to call each time a request is being stubbed by OHHTTPStubs.
  *               Set it to `nil` to do nothing. Defaults is `nil`.
  */
-+(void)onStubActivation:( void(^)(NSURLRequest* request, id<OHHTTPStubsDescriptor> stub) )block;
++(void)onStubActivation:( nullable void(^)(NSURLRequest* request, id<OHHTTPStubsDescriptor> stub) )block;
 
 @end
 

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -198,7 +198,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
     return [OHHTTPStubs.sharedInstance stubDescriptors];
 }
 
-+(void)onStubActivation:( void(^)(NSURLRequest* request, id<OHHTTPStubsDescriptor> stub) )block
++(void)onStubActivation:( nullable void(^)(NSURLRequest* request, id<OHHTTPStubsDescriptor> stub) )block
 {
     [OHHTTPStubs.sharedInstance setOnStubActivationBlock:block];
 }

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -44,7 +44,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
 @interface OHHTTPStubs()
 + (instancetype)sharedInstance;
 @property(atomic, copy) NSMutableArray* stubDescriptors;
-@property(atomic, copy) void (^onStubActivationBlock)(NSURLRequest*, id<OHHTTPStubsDescriptor>);
+@property(atomic, copy, nullable) void (^onStubActivationBlock)(NSURLRequest*, id<OHHTTPStubsDescriptor>);
 @end
 
 @interface OHHTTPStubsDescriptor : NSObject <OHHTTPStubsDescriptor>


### PR DESCRIPTION
The documentation comment for `-onStubActivation:` says that the block can be `nil`:
> Set it to `nil` to do nothing. Defaults is `nil`

The file is within `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END` so I get a warning 
> :warning: Null passed to a callee that requires a non-null argument

when I pass `nil` for the block parameter.
I have added `nullable` to the method signature to avoid the warning.