### PR TITLE
Added isEnabled getters for OHHTTPStubs.

### DIFF
--- a/OHHTTPStubs/Sources/OHHTTPStubs.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.h
@@ -128,6 +128,13 @@ typedef OHHTTPStubsResponse* __nonnull (^OHHTTPStubsResponseBlock)( NSURLRequest
  */
 +(void)setEnabled:(BOOL)enabled;
 
+/**
+ *  Whether or not stubs are enabled for the shared session or for `NSURLConnection`
+ *
+ *  @return If `YES` the stubs are enabled. If `NO` then the stubs are disabled
+ */
++(BOOL)isEnabled;
+
 #if defined(__IPHONE_7_0) || defined(__MAC_10_9)
 /**
  *  Enable or disable the stubs on a given `NSURLSessionConfiguration`.
@@ -149,6 +156,15 @@ typedef OHHTTPStubsResponse* __nonnull (^OHHTTPStubsResponseBlock)( NSURLRequest
  *        created sessions.
  */
 + (void)setEnabled:(BOOL)enabled forSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig;
+
+/**
+ *  Whether stubs are enabled or disabled on a given `NSURLSessionConfiguration`
+ *
+ *  @param sessionConfig The NSURLSessionConfiguration on which to enable/disable the stubs
+ *
+ *  @return If `YES` the stubs are enabled for sessionConfig. If `NO` then the stubs are disabled
+ */
++ (BOOL)isEnabledForSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig;
 #endif
 
 #pragma mark - Debug Methods

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -44,7 +44,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
 @interface OHHTTPStubs()
 + (instancetype)sharedInstance;
 @property(atomic, copy) NSMutableArray* stubDescriptors;
-@property(atomic, copy) NSNumber* enabledStateNumber;
+@property(atomic, assign) BOOL enabledState;
 @property(atomic, copy, nullable) void (^onStubActivationBlock)(NSURLRequest*, id<OHHTTPStubsDescriptor>);
 @end
 
@@ -115,7 +115,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
     if (self)
     {
         _stubDescriptors = [NSMutableArray array];
-        _enabledStateNumber = @YES; // assume initialize has already been run
+        _enabledState = YES; // assume initialize has already been run
     }
     return self;
 }
@@ -248,7 +248,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
     BOOL enabled = NO;
     @synchronized(self)
     {
-        enabled = _enabledStateNumber.boolValue;
+        enabled = _enabledState;
     }
     return enabled;
 }
@@ -257,8 +257,8 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
 {
     @synchronized(self)
     {
-        _enabledStateNumber = @(enable);
-        [self.class _setEnable:enable];
+        _enabledState = enable;
+        [self.class _setEnable:_enabledState];
     }
 }
 

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -208,13 +208,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
     {
         NSMutableArray * urlProtocolClasses = [NSMutableArray arrayWithArray:sessionConfig.protocolClasses];
         Class protoCls = OHHTTPStubsProtocol.class;
-        if ([urlProtocolClasses containsObject:protoCls])
-        {
-            return YES;
-        } else
-        {
-            return NO;
-        }
+        return [urlProtocolClasses containsObject:protoCls];
     }
     else
     {


### PR DESCRIPTION
Reflects current implementation. This branch does not update the version or run `pod update` for the examples. There is a minor bug in Cocoapods for building projects for different platforms. Not sure how you build your projects so I can add that to the branch when I know what to do. This is in response to https://github.com/AliSoftware/OHHTTPStubs/issues/139