### PR TITLE
Let Travis auto deploy carthage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,16 @@ env:
 
 script:
   - rake "$RAKETASK"
+
+before_deploy:
+  - carthage build --no-skip-current
+  - carthage archive OHHTTPStubs
+
+deploy:
+  provider: releases
+  api_key:
+    secure:
+  file: OHHTTPStubs.framework.zip
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
This tells Travis to build and attach prebuilt framework archives to the GitHub releases.
In order for this to work you'll need to add your encrypted API key by running

    travis setup releases

See https://docs.travis-ci.com/user/deployment/releases