### PR TITLE
Fix for issue #174 - NSURLSessionTask completion block not called when not following redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+* Bugfix: task completion block never called when not following redirects.
+  [@adurdin](https://github.com/adurdin), [#175](https://github.com/AliSoftware/OHHTTPStubs/pull/175)
+
 * Declare in the project settings that the library contains swift code.  
   [@rodericj](https://github.com/rodericj), [#173](https://github.com/AliSoftware/OHHTTPStubs/pull/173)
 

--- a/OHHTTPStubs/UnitTests/Test Suites/AFNetworkingTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/AFNetworkingTests.m
@@ -125,32 +125,35 @@ static const NSTimeInterval kResponseTimeTolerence = 1.0;
     static const NSTimeInterval kRequestTime = 0.05;
     static const NSTimeInterval kResponseTime = 0.1;
     
-    NSURL* redirectURL = [NSURL URLWithString:@"http://www.iana.org/domains/another/example"];
+    NSURL* redirectURL = [NSURL URLWithString:@"https://httpbin.org/get"];
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return YES;
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
-        return [[OHHTTPStubsResponse responseWithData:[NSData data] statusCode:311 headers:@{@"Location":redirectURL.absoluteString}]
+        return [[OHHTTPStubsResponse responseWithData:[NSData data] statusCode:302 headers:@{@"Location":redirectURL.absoluteString}]
                 requestTime:kRequestTime responseTime:kResponseTime];
     }];
     
+    XCTestExpectation* redirectExpectation = [self expectationWithDescription:@"AFHTTPRequestOperation request was redirected"];
     XCTestExpectation* expectation = [self expectationWithDescription:@"AFHTTPRequestOperation request finished"];
-    
-    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.iana.org/domains/example/"]];
+
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/redirect/1"]];
     AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
-    [manager setResponseSerializer:[AFHTTPResponseSerializer serializer]];
-    
+    AFHTTPResponseSerializer *serializer = [AFHTTPResponseSerializer serializer];
+    serializer.acceptableStatusCodes = [NSIndexSet indexSetWithIndex:302];
+    [manager setResponseSerializer:serializer];
+
     __block __strong NSURL* url = nil;
     [manager setTaskWillPerformHTTPRedirectionBlock:^NSURLRequest * (NSURLSession * session, NSURLSessionTask * task, NSURLResponse * response, NSURLRequest * request) {
         if (response == nil) {
             return request;
         }
         url = request.URL;
-        [expectation fulfill];
+        [redirectExpectation fulfill];
         return nil;
     }];
     
     [manager GET:req.URL.absoluteString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
-        XCTFail(@"Unexpected response");
+        // Expect the 302 response when the redirection block returns nil (don't follow redirects)
         [expectation fulfill];
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         XCTFail(@"Unexpected network failure");
@@ -161,6 +164,52 @@ static const NSTimeInterval kResponseTimeTolerence = 1.0;
     
     XCTAssertEqualObjects(url, redirectURL, @"Unexpected data received");
 }
+
+/*
+ * In order to establish that test_AFHTTPRequestOperation_redirect was incorrect and needed fixing, I needed
+ * to demonstrate identical behaviour--that is, returning the redirect response itself to the success block--
+ * when running without the NSURLProtocol stubbing the request. The test below, if enabled, establishes this,
+ * as it is identical to test_AFHTTPRequestOperation_redirect except that it does not stub the requests.
+ */
+#if 0
+-(void)test_AFHTTPRequestOperation_redirect_baseline
+{
+    NSURL* redirectURL = [NSURL URLWithString:@"https://httpbin.org/get"];
+
+    XCTestExpectation* redirectExpectation = [self expectationWithDescription:@"AFHTTPRequestOperation request was redirected"];
+    XCTestExpectation* expectation = [self expectationWithDescription:@"AFHTTPRequestOperation request finished"];
+
+    NSURLRequest* req = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/redirect/1"]];
+    AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+    AFHTTPResponseSerializer *serializer = [AFHTTPResponseSerializer serializer];
+    serializer.acceptableStatusCodes = [NSIndexSet indexSetWithIndex:302];
+    [manager setResponseSerializer:serializer];
+
+    __block __strong NSURL* url = nil;
+    [manager setTaskWillPerformHTTPRedirectionBlock:^NSURLRequest * (NSURLSession * session, NSURLSessionTask * task, NSURLResponse * response, NSURLRequest * request) {
+        if (response == nil) {
+            return request;
+        }
+        url = request.URL;
+        [redirectExpectation fulfill];
+        return nil;
+    }];
+
+    [manager GET:req.URL.absoluteString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
+        // Expect the 302 response when the redirection block returns nil (don't follow redirects)
+        [expectation fulfill];
+    } failure:^(NSURLSessionTask *operation, NSError *error) {
+        XCTFail(@"Unexpected network failure");
+        [expectation fulfill];
+    }];
+
+    // Allow a longer timeout as this test actually hits the network
+    [self waitForExpectationsWithTimeout:10 handler:nil];
+
+    XCTAssertEqualObjects(url, redirectURL, @"Unexpected data received");
+}
+#endif
+
 
 @end
 


### PR DESCRIPTION
The standard behaviour of NSURLSession, when its delegate says not to follow redirects, and when no custom NSURLProtocol is managing things is to call the completion block with the actual redirect response, its data, and a nil error.

These commits fix OHHTTPStubsProtocol to implement the same behaviour. The behaviour when the delegate says to follow redirects is unchanged.

Note that [Apple’s CustomHTTPProtocol sample code](https://developer.apple.com/library/ios/samplecode/CustomHTTPProtocol/Introduction/Intro.html) instead completes the redirect response with an NSURLErrorCancelled error, diverging from the standard behaviour.