### PR TITLE
[Travis] Use `build-for-testing` and `test-without-building` build actions on Xcode 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,19 @@ matrix:
 #     - osx_image: xcode7.3
 #       env: RAKETASK="simlist"
 #     - osx_image: xcode7.3
-#       env: RAKETASK="ios[iOS StaticLib,7.1,test]"
+#       env: RAKETASK="ios[iOS StaticLib,7.1,build test]"
     - osx_image: xcode7.3
-      env: RAKETASK="ios[iOS StaticLib,latest,test]"
+      env: RAKETASK="ios[iOS StaticLib,latest,build test]"
     - osx_image: xcode7.3
-      env: RAKETASK="ios[iOS Framework,latest,test]"
+      env: RAKETASK="ios[iOS Framework,latest,build test]"
     - osx_image: xcode7.3
-      env: RAKETASK="osx[Mac Framework,x86_64,test]"
+      env: RAKETASK="osx[Mac Framework,x86_64,build test]"
     - osx_image: xcode7.3
-      env: RAKETASK="tvos[tvOS Framework,latest,test]"
+      env: RAKETASK="tvos[tvOS Framework,latest,build test]"
 #     - osx_image: xcode8
 #       env: RAKETASK="simlist"
 #     - osx_image: xcode8
-#       env: RAKETASK="ios[iOS StaticLib,7.1,test]"
+#       env: RAKETASK="ios[iOS StaticLib,7.1,build-for-testing test-without-building]"
     - osx_image: xcode8
       env: RAKETASK="ios[iOS StaticLib,latest,build-for-testing test-without-building]"
     - osx_image: xcode8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
 #     - osx_image: xcode8
 #       env: RAKETASK="ios[iOS StaticLib,7.1,test]"
     - osx_image: xcode8
-      env: RAKETASK="ios[iOS StaticLib,latest,test]"
+      env: RAKETASK="ios[iOS StaticLib,latest,build-for-testing test-without-building]"
     - osx_image: xcode8
-      env: RAKETASK="ios[iOS Framework,latest,test]"
+      env: RAKETASK="ios[iOS Framework,latest,build-for-testing test-without-building]"
     - osx_image: xcode8
-      env: RAKETASK="osx[Mac Framework,x86_64,test]"
+      env: RAKETASK="osx[Mac Framework,x86_64,build-for-testing test-without-building]"
     - osx_image: xcode8
-      env: RAKETASK="tvos[tvOS Framework,latest,test]"
+      env: RAKETASK="tvos[tvOS Framework,latest,build-for-testing test-without-building]"
 
 script:
   - rake "$RAKETASK"


### PR DESCRIPTION
This should stabilize running iOS tests on Travis with Xcode 8. See https://github.com/AliSoftware/OHHTTPStubs/pull/184#issuecomment-232067292 for the original concern.