### PR TITLE
Migrate samples to Swift 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OHHTTPStubs — CHANGELOG
 
+* Migrate samples to Swift 3
+  [@dhardiman](https://gitub.com/dhardiman)
+
 ## [5.2.1](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/5.2.0)
 
 * Fix typos in README and documentation.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OHHTTPStubs — CHANGELOG
 
-* Migrate samples to Swift 3
+* Migrate samples to Swift 3.  
   [@dhardiman](https://gitub.com/dhardiman)
 
 ## [5.2.1](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/5.2.0)

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Examples/Swift/MainViewController.swift
+++ b/Examples/Swift/MainViewController.swift
@@ -28,21 +28,21 @@ class MainViewController: UIViewController {
 
         installTextStub(self.installTextStubSwitch)
         installImageStub(self.installImageStubSwitch)
-        OHHTTPStubs.onStubActivation { (request: NSURLRequest, stub: OHHTTPStubsDescriptor, response: OHHTTPStubsResponse) in
-            print("[OHHTTPStubs] Request to \(request.URL!) has been stubbed with \(stub.name)")
+        OHHTTPStubs.onStubActivation { (request: URLRequest, stub: OHHTTPStubsDescriptor, response: OHHTTPStubsResponse) in
+            print("[OHHTTPStubs] Request to \(request.url!) has been stubbed with \(stub.name)")
         }
     }
 
     ////////////////////////////////////////////////////////////////////////////////
     // MARK: - Global stubs activation
 
-    @IBAction func toggleStubs(sender: UISwitch) {
-        OHHTTPStubs.setEnabled(sender.on)
-        self.delaySwitch.enabled = sender.on
-        self.installTextStubSwitch.enabled = sender.on
-        self.installImageStubSwitch.enabled = sender.on
+    @IBAction func toggleStubs(_ sender: UISwitch) {
+        OHHTTPStubs.setEnabled(sender.isOn)
+        self.delaySwitch.isEnabled = sender.isOn
+        self.installTextStubSwitch.isEnabled = sender.isOn
+        self.installImageStubSwitch.isEnabled = sender.isOn
         
-        let state = sender.on ? "and enabled" : "but disabled"
+        let state = sender.isOn ? "and enabled" : "but disabled"
         print("Installed (\(state)) stubs: \(OHHTTPStubs.allStubs)")
     }
     
@@ -52,30 +52,30 @@ class MainViewController: UIViewController {
     // MARK: - Text Download and Stub
     
     
-    @IBAction func downloadText(sender: UIButton) {
-        sender.enabled = false
+    @IBAction func downloadText(_ sender: UIButton) {
+        sender.isEnabled = false
         self.textView.text = nil
         
         let urlString = "http://www.opensource.apple.com/source/Git/Git-26/src/git-htmldocs/git-commit.txt?txt"
-        let req = NSURLRequest(URL: NSURL(string: urlString)!)
+        let req = URLRequest(url: URL(string: urlString)!)
 
-        NSURLConnection.sendAsynchronousRequest(req, queue: NSOperationQueue.mainQueue()) { (_, data, _) in
-            sender.enabled = true
-            if let receivedData = data, receivedText = NSString(data: receivedData, encoding: NSASCIIStringEncoding) {
+        NSURLConnection.sendAsynchronousRequest(req, queue: OperationQueue.main) { (_, data, _) in
+            sender.isEnabled = true
+            if let receivedData = data, let receivedText = NSString(data: receivedData, encoding: String.Encoding.ascii.rawValue) {
                 self.textView.text = receivedText as String
             }
         }
     }
 
     weak var textStub: OHHTTPStubsDescriptor?
-    @IBAction func installTextStub(sender: UISwitch) {
-        if sender.on {
+    @IBAction func installTextStub(_ sender: UISwitch) {
+        if sender.isOn {
             // Install
 
             textStub = stub(isExtension("txt")) { _ in
-                let stubPath = OHPathForFile("stub.txt", self.dynamicType)
+                let stubPath = OHPathForFile("stub.txt", type(of: self))
                 return fixture(stubPath!, headers: ["Content-Type":"text/plain"])
-                    .requestTime(self.delaySwitch.on ? 2.0 : 0.0, responseTime:OHHTTPStubsDownloadSpeedWifi)
+                    .requestTime(self.delaySwitch.isOn ? 2.0 : 0.0, responseTime:OHHTTPStubsDownloadSpeedWifi)
             }
             textStub?.name = "Text stub"
         } else {
@@ -88,15 +88,15 @@ class MainViewController: UIViewController {
     ////////////////////////////////////////////////////////////////////////////////
     // MARK: - Image Download and Stub
     
-    @IBAction func downloadImage(sender: UIButton) {
-        sender.enabled = false
+    @IBAction func downloadImage(_ sender: UIButton) {
+        sender.isEnabled = false
         self.imageView.image = nil
 
         let urlString = "http://images.apple.com/support/assets/images/products/iphone/hero_iphone4-5_wide.png"
-        let req = NSURLRequest(URL: NSURL(string: urlString)!)
+        let req = URLRequest(url: URL(string: urlString)!)
 
-        NSURLConnection.sendAsynchronousRequest(req, queue: NSOperationQueue.mainQueue()) { (_, data, _) in
-            sender.enabled = true
+        NSURLConnection.sendAsynchronousRequest(req, queue: OperationQueue.main) { (_, data, _) in
+            sender.isEnabled = true
             if let receivedData = data {
                 self.imageView.image = UIImage(data: receivedData)
             }
@@ -104,14 +104,14 @@ class MainViewController: UIViewController {
     }
     
     weak var imageStub: OHHTTPStubsDescriptor?
-    @IBAction func installImageStub(sender: UISwitch) {
-        if sender.on {
+    @IBAction func installImageStub(_ sender: UISwitch) {
+        if sender.isOn {
             // Install
             
             imageStub = stub(isExtension("png") || isExtension("jpg") || isExtension("gif")) { _ in
-                let stubPath = OHPathForFile("stub.jpg", self.dynamicType)
+                let stubPath = OHPathForFile("stub.jpg", type(of: self))
                 return fixture(stubPath!, headers: ["Content-Type":"image/jpeg"])
-                    .requestTime(self.delaySwitch.on ? 2.0 : 0.0, responseTime: OHHTTPStubsDownloadSpeedWifi)
+                    .requestTime(self.delaySwitch.isOn ? 2.0 : 0.0, responseTime: OHHTTPStubsDownloadSpeedWifi)
             }
             imageStub?.name = "Image stub"
         } else {

--- a/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
+++ b/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 				TargetAttributes = {
 					099F74061AE2D049001108A5 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -341,6 +342,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -354,6 +356,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Examples/Swift/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Swift/Pods/Pods.xcodeproj/project.pbxproj
@@ -434,6 +434,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					52BC854E06FCDCDB1DEE75DA7A418EC6 = {
+						LastSwiftMigration = 0800;
+					};
+					819D98B2274D0D02398DA2FD14346272 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -559,6 +567,7 @@
 				PRODUCT_NAME = Pods_OHHTTPStubsDemo;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -593,6 +602,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -622,6 +632,7 @@
 				PRODUCT_NAME = OHHTTPStubs;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -690,6 +701,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -1319,7 +1319,7 @@
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -1359,7 +1359,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
Carthage seems to find this example project and fall over when the dependencies are checked using Xcode 8 as it’s not specifying the swift version. This appears to fix that. It does seem to build the framework target twice due to the cocoa pods usage for the example, but I don’t think that causes a problem. Perhaps in future the example project could link directly to the project rather than using CocoaPods to solve that, but probably not urgent.