### PR TITLE
Add OHHTTPStubs_HTTPBody to URLRequest in Swift 3.0

### DIFF
--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -28,6 +28,11 @@
 
 
 #if swift(>=3.0)
+    extension URLRequest {
+        public var ohhttpStubs_httpBody: Data? {
+            return (self as NSURLRequest).ohhttpStubs_HTTPBody()
+        }
+    }
 #else
 #if swift(>=2.2)
     extension OHHTTPStubs {

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -382,4 +382,13 @@ class SwiftHelpersTests : XCTestCase {
       XCTAssert((!falseMatcher)(req) == true, "!falseMatcher should result in a trueMatcher")
     }
   }
+
+  #if swift(>=3.0)
+    func test_ohhttpStubs_httpBody {
+      var req = URLRequest(url: URL(string: "foo://bar")!)
+      req.httpBody = Data()
+
+      XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
+    }
+  #endif
 }


### PR DESCRIPTION
Fixes #215 

I wasn't able to figure out a way to run the tests with Swift 3.0 though