### PR TITLE
Switching ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to No

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -1489,7 +1489,6 @@
 		095981E119806A7900807DBE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1517,7 +1516,6 @@
 		095981E219806A7900807DBE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -1544,7 +1542,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FADAD1A74682F410A97EE06F /* Pods-TestingPods-OHHTTPStubs Mac Tests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1573,7 +1570,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 070E9B74647A6F3AE67C97A7 /* Pods-TestingPods-OHHTTPStubs Mac Tests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1599,7 +1595,6 @@
 		725CD9AE1A9EB65200F84C8B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1624,7 +1619,6 @@
 		725CD9AF1A9EB65200F84C8B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1683,7 +1677,6 @@
 		EAA436A31BE1598D000E9E99 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1708,7 +1701,6 @@
 		EAA436A41BE1598D000E9E99 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
Embedding the libraries is causing packaging archives to an `.ipa` to fail like so:

```
INFO [2016-10-20 22:14:16.77]: ▸ + xcodebuild -exportArchive -exportOptionsPlist /var/folders/qv/8ntp55hd26j0zsrdt5tshr900000gn/T/gym_config20161020-99083-8ecbyq.plist -archivePath '/Users/kylejm/Library/Developer/Xcode/Archives/2016-10-20/Loot Release 2016-10-20 22.09.51.xcarchive' -exportPath /var/folders/qv/8ntp55hd26j0zsrdt5tshr900000gn/T/gym_output20161020-99083-i6w8o4
INFO [2016-10-20 22:14:17.97]: ▸ 2016-10-20 22:14:17.976 xcodebuild[99721:3856687] [MT] IDEDistribution: -[IDEDistributionLogging _createLoggingBundleAtPath:]: Created bundle at path '/var/folders/qv/8ntp55hd26j0zsrdt5tshr900000gn/T/Loot Release_2016-10-20_22-14-17.975.xcdistributionlogs'.
INFO [2016-10-20 22:14:19.06]: ▸ 1.2.840.113635.100.1.61
INFO [2016-10-20 22:14:20.25]: ▸ 2016-10-20 22:14:20.253 xcodebuild[99721:3856687] [MT] DVTAssertions: ASSERTION FAILURE in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-11246/IDEFoundation/Distribution/IDEDistributionSummaryStep.m:213
INFO [2016-10-20 22:14:20.25]: ▸ Details:  A method claimed to have succeeded but provided an error!
INFO [2016-10-20 22:14:20.25]: ▸ Object:   <IDEDistributionSummaryStep>
INFO [2016-10-20 22:14:20.25]: ▸ Method:   +_distributionItemsWithoutBitcodeForPlatforms:flattenedDistributionItems:archive:withError:
INFO [2016-10-20 22:14:20.25]: ▸ Thread:   <NSThread: 0x7fecd6511430>{number = 1, name = main}
INFO [2016-10-20 22:14:20.25]: ▸ Hints: None
INFO [2016-10-20 22:14:20.25]: ▸ Backtrace:
INFO [2016-10-20 22:14:20.25]: ▸ 0   -[DVTAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] (in DVTFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 1   _DVTAssertionHandler (in DVTFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 2   _DVTAssertionFailureHandler (in DVTFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 3   +[IDEDistributionSummaryStep _distributionItemsWithoutBitcodeForPlatforms:flattenedDistributionItems:archive:withError:] (in IDEFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 4   -[IDEDistributionSummaryStep distributionItemsWithoutBitcodeForPlatforms:withError:] (in IDEFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 5   -[IDEDistributionSummaryStep loadFromPropertyList:error:] (in IDEFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 6   -[IDEDistributionDriver runWithDestinationPath:error:] (in IDEFoundation)
INFO [2016-10-20 22:14:20.25]: ▸ 7   -[Xcode3CommandLineBuildTool _distributeArchiveAndExit] (in Xcode3Core)
INFO [2016-10-20 22:14:20.25]: ▸ 8   -[Xcode3CommandLineBuildTool run] (in Xcode3Core)
INFO [2016-10-20 22:14:20.26]: ▸ 9  0x0000000101ab2202 (in xcodebuild)
INFO [2016-10-20 22:14:20.26]: ▸ 10   start (in libdyld.dylib)
```

After a few hours of confusion, I found [this thread](https://forums.developer.apple.com/thread/54445), where zirinisp talks about this fix:

```
zirinisp
Oct 3, 2016 12:02 AM
(in response to zirinisp)
I finally found a solution to the above problem. I had a framework (added through carthage) that was including libraries and other frameworks. You can identify that you have the same problem as me using the following steps:
 
- Do a carthage update and add all framework on xcode (you have probably already done this step when you setup xcode).
- Then open xcode and on the left side go to the frameworks folden and expand.
- You should get a list with all frameworks installed
- Then expand each framework.
- You should only see a folder called "Headers"
- If you see a folder called "Frameworks", then you have the problem I had.
 
To solve it you need to create a fork on github (or the git site that you checked out the framework) and go to the build settings and set the following:
 
ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
```

I can now package our application by targeting our branch with this fix :tada:.

Relates to [an issue](https://github.com/fastlane/fastlane/issues/6591) with with gym from fastlane.