### PR TITLE
Minor documentation update for Swift 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This example is using the Swift helpers found in `OHHTTPStubsSwift.swift` provid
 ```swift
 stub(isHost("mywebservice.com")) { _ in
   // Stub it with our "wsresponse.json" stub file (which is in same bundle as self)
-  let stubPath = OHPathForFile("wsresponse.json", self.dynamicType)
-  return fixture(stubPath!, headers: ["Content-Type":"application/json"])
+  let stubPath = OHPathForFile("wsresponse.json", type(of: self))
+  return fixture(filePath: stubPath!, headers: ["Content-Type":"application/json"])
 }
 ```
 


### PR DESCRIPTION
Previous documentation was not quite working in Swift, due to:
- String not implicitly casted to NSString / NSObject / AnyObject
- missing external parameter name.