### PR TITLE
Update syntax and build settings to Swift 3.1

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -812,7 +812,7 @@
 						TestTargetID = 09110A4019805F4800D175E4;
 					};
 					093442DD1B80EC4A00A91535 = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					095981D119806A7900807DBE = {
 						LastSwiftMigration = 0800;
@@ -820,7 +820,7 @@
 					};
 					725CD99A1A9EB65100F84C8B = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					EA100AB61BE15BE400129352 = {
 						CreatedOnToolsVersion = 7.1;
@@ -1319,7 +1319,7 @@
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -1359,7 +1359,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1457,6 +1457,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -1482,6 +1483,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;
@@ -1612,6 +1614,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = OHHTTPStubs;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1633,6 +1636,7 @@
 				PRODUCT_NAME = OHHTTPStubs;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -31,27 +31,27 @@
 #else
 #if swift(>=2.2)
     extension OHHTTPStubs {
-        private class func stubRequests(passingTest passingTest: OHHTTPStubsTestBlock, withStubResponse: OHHTTPStubsResponseBlock) -> OHHTTPStubsDescriptor {
-            return stubRequestsPassingTest(passingTest, withStubResponse: withStubResponse)
+        fileprivate class func stubRequests(passingTest: OHHTTPStubsTestBlock, withStubResponse: OHHTTPStubsResponseBlock) -> OHHTTPStubsDescriptor {
+            return self.stubRequests(passingTest: passingTest, withStubResponse: withStubResponse)
         }
     }
 
-    extension NSURLRequest {
-        var httpMethod: String? { return HTTPMethod }
-        var url: NSURL? { return URL }
+    extension Foundation.URLRequest {
+        var httpMethod: String? { return httpMethod }
+        var url: URL? { return url }
     }
 
-    extension NSURLComponents {
-        private convenience init?(url: NSURL, resolvingAgainstBaseURL: Bool) {
-            self.init(URL: url, resolvingAgainstBaseURL: resolvingAgainstBaseURL)
+    extension URLComponents {
+        fileprivate convenience init?(url: URL, resolvingAgainstBaseURL: Bool) {
+            (self as NSURLComponents).init(url: url, resolvingAgainstBaseURL: resolvingAgainstBaseURL)
         }
     }
 
-    private typealias URLRequest = NSURLRequest
+    private typealias URLRequest = Foundation.URLRequest
 
     extension URLRequest {
-        private func value(forHTTPHeaderField key: String) -> String? {
-            return valueForHTTPHeaderField(key)
+        fileprivate func value(forHTTPHeaderField key: String) -> String? {
+            return self.value(forHTTPHeaderField: key)
         }
     }
 #endif
@@ -70,7 +70,7 @@
  * - Returns: The `OHHTTPStubsResponse` instance that will stub with the given status code
  *            & headers, and use the file content as the response body.
  */
-public func fixture(filePath: String, status: Int32 = 200, headers: [NSObject: AnyObject]?) -> OHHTTPStubsResponse {
+public func fixture(_ filePath: String, status: Int32 = 200, headers: [AnyHashable: Any]?) -> OHHTTPStubsResponse {
     return OHHTTPStubsResponse(fileAtPath: filePath, statusCode: status, headers: headers)
 }
 
@@ -89,7 +89,7 @@ public func stub(condition: @escaping OHHTTPStubsTestBlock, response: @escaping 
     return OHHTTPStubs.stubRequests(passingTest: condition, withStubResponse: response)
 }
 #else
-public func stub(condition: OHHTTPStubsTestBlock, response: OHHTTPStubsResponseBlock) -> OHHTTPStubsDescriptor {
+public func stub(_ condition: OHHTTPStubsTestBlock, response: OHHTTPStubsResponseBlock) -> OHHTTPStubsDescriptor {
     return OHHTTPStubs.stubRequests(passingTest: condition, withStubResponse: response)
 }
 #endif
@@ -184,7 +184,7 @@ public func isHost(_ host: String) -> OHHTTPStubsTestBlock {
  *         should include in the `path` parameter unless you're testing relative URLs)
  */
 public func isPath(_ path: String) -> OHHTTPStubsTestBlock {
-    return { req in (req.url as NSURL?)?.path == path } // Need to cast to NSURL because URL.path does not behave like NSURL.path in Swift 3.0. URL.path does not stop at the first ';' and returns the entire string.
+    return { req in (req.url as URL?)?.path == path } // Need to cast to NSURL because URL.path does not behave like NSURL.path in Swift 3.0. URL.path does not stop at the first ';' and returns the entire string.
 }
 
 /**
@@ -234,7 +234,7 @@ public func isExtension(_ ext: String) -> OHHTTPStubsTestBlock {
 public func containsQueryParams(_ params: [String:String?]) -> OHHTTPStubsTestBlock {
     return { req in
         if let url = req.url {
-            let comps = NSURLComponents(url: url, resolvingAgainstBaseURL: true)
+            let comps = URLComponents(url: url, resolvingAgainstBaseURL: true)
             if let queryItems = comps?.queryItems {
                 for (k,v) in params {
                     if queryItems.filter({ qi in qi.name == k && qi.value == v }).count == 0 { return false }

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -13,19 +13,19 @@ import XCTest
 #if swift(>=3.0)
 #else
 #if swift(>=2.2)
-    extension SequenceType {
-        private func enumerated() -> EnumerateSequence<Self> {
-            return enumerate()
+    extension Sequence {
+        fileprivate func enumerated() -> EnumeratedSequence<Self> {
+            return self.enumerated()
         }
     }
 
     extension NSMutableURLRequest {
         override var httpMethod: String? {
             get {
-                return HTTPMethod
+                return httpMethod
             }
             set(method) {
-                self.HTTPMethod = method!
+                self.httpMethod = method!
             }
         }
     }
@@ -42,7 +42,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       var req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-      let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
+      let req = NSMutableURLRequest(url: URL(string: "foo://bar")!)
 #endif
       req.httpMethod = method
       for (idxMatcher, matcher) in matchers.enumerated() {
@@ -68,7 +68,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert(matcher(req) == result, "isScheme(\"foo\") matcher failed when testing url \(url)")
     }
@@ -89,7 +89,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert(matcher(req) == result, "isHost(\"foo\") matcher failed when testing url \(url)")
     }
@@ -135,7 +135,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       let p = req.url?.path
       print("URL: \(url) -> Path: \(p)")
@@ -184,7 +184,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       let p = req.url?.path
       print("URL: \(url) -> Path: \(p)")
@@ -209,7 +209,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert(matcher(req) == result, "isExtension(\"txt\") matcher failed when testing url \(url)")
     }
@@ -245,7 +245,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
 
       XCTAssert(matcher(req) == result, "containsQueryParams(\"\(params)\") matcher failed when testing url \(url)")
@@ -256,7 +256,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
     var req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-    let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = NSMutableURLRequest(url: URL(string: "foo://bar")!)
 #endif
     req.addValue("1234567890", forHTTPHeaderField: "ArbitraryKey")
 
@@ -269,7 +269,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
     let req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-    let req = NSURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = URLRequest(url: URL(string: "foo://bar")!)
 #endif
 
     let hasHeader = hasHeaderNamed("ArbitraryKey")(req)
@@ -281,7 +281,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
     var req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-    let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = NSMutableURLRequest(url: URL(string: "foo://bar")!)
 #endif
     req.addValue("bar", forHTTPHeaderField: "foo")
     
@@ -294,7 +294,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
     var req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-    let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = NSMutableURLRequest(url: URL(string: "foo://bar")!)
 #endif
     req.addValue("bar", forHTTPHeaderField: "foo")
     
@@ -307,7 +307,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
     let req = URLRequest(url: URL(string: "foo://bar")!)
 #else
-    let req = NSURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = URLRequest(url: URL(string: "foo://bar")!)
 #endif
 
     let matchesHeader = hasHeaderNamed("foo", value: "baz")(req)
@@ -348,7 +348,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert((trueMatcher || trueMatcher)(req) == true, "trueMatcher || trueMatcher should result in a trueMatcher")
       XCTAssert((trueMatcher || falseMatcher)(req) == true, "trueMatcher || falseMatcher should result in a trueMatcher")
@@ -362,7 +362,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert((trueMatcher && trueMatcher)(req) == true, "trueMatcher && trueMatcher should result in a trueMatcher")
       XCTAssert((trueMatcher && falseMatcher)(req) == false, "trueMatcher && falseMatcher should result in a falseMatcher")
@@ -376,7 +376,7 @@ class SwiftHelpersTests : XCTestCase {
 #if swift(>=3.0)
       let req = URLRequest(url: URL(string: url)!)
 #else
-      let req = NSURLRequest(URL: NSURL(string: url)!)
+      let req = URLRequest(url: URL(string: url)!)
 #endif
       XCTAssert((!trueMatcher)(req) == false, "!trueMatcher should result in a falseMatcher")
       XCTAssert((!falseMatcher)(req) == true, "!falseMatcher should result in a trueMatcher")

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Hopefully, Carthage will address this in a future release. See the related issue
 
 ## Automatic loading
 
-Thanks to method swizzling, `OHHTTPStubs` is automatically loaded and installed both for:
+`OHHTTPStubs` is automatically loaded and installed (at the time the library is loaded in memory), both for:
 
-* requests made using `NSURLConnection` or `[NSURLSession sharedSession]`;
-* requests made using a `NSURLSession` created using a `[NSURLSessionConfiguration defaultSessionConfiguration]` or `[NSURLSessionConfiguration ephemeralSessionConfiguration]` configuration (using `[NSURLSession sessionWithConfiguration:…]`-like methods).
+* requests made using `NSURLConnection` or `[NSURLSession sharedSession]` — [thanks to this code](https://github.com/AliSoftware/OHHTTPStubs/blob/master/OHHTTPStubs/Sources/OHHTTPStubs.m#L107-L113)
+* requests made using a `NSURLSession` that was created via `[NSURLSession sessionWithConfiguration:…]` and using either `[NSURLSessionConfiguration defaultSessionConfiguration]` or `[NSURLSessionConfiguration ephemeralSessionConfiguration]` configuration — thanks to [method swizzling](http://nshipster.com/method-swizzling/) done [here in the code](https://github.com/AliSoftware/OHHTTPStubs/blob/master/OHHTTPStubs/Sources/NSURLSession/OHHTTPStubs+NSURLSessionConfiguration.m).
 
 If you need to disable (and re-enable) `OHHTTPStubs` — globally or per `NSURLSession` — you can use `[OHHTTPStubs setEnabled:]` / `[OHHTTPStubs setEnabled:forSessionConfiguration:]`.
 


### PR DESCRIPTION
This allows compilation for machines updated to Xcode 8.3 with Swift 3.1.