### PR TITLE
Xcode 8.3 and Swift 3.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ matrix:
       env: RAKETASK="osx[Mac Framework,x86_64,build test,-DOHHTTPSTUBS_SKIP_TIMING_TESTS=1]"
     - osx_image: xcode7.3
       env: RAKETASK="tvos[tvOS Framework,latest,build test,-DOHHTTPSTUBS_SKIP_TIMING_TESTS=1]"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env: RAKETASK="ios[iOS StaticLib,latest,build-for-testing test-without-building,-DOHHTTPSTUBS_SKIP_TIMING_TESTS=1]"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env: RAKETASK="ios[iOS Framework,latest,build-for-testing test-without-building]"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env: RAKETASK="osx[Mac Framework,x86_64,build-for-testing test-without-building,-DOHHTTPSTUBS_SKIP_TIMING_TESTS=1]"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env: RAKETASK="tvos[tvOS Framework,latest,build-for-testing test-without-building,-DOHHTTPSTUBS_SKIP_TIMING_TESTS=1]"
 
 script:

--- a/Examples/Swift/AppDelegate.swift
+++ b/Examples/Swift/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Examples/Swift/MainViewController.swift
+++ b/Examples/Swift/MainViewController.swift
@@ -28,21 +28,21 @@ class MainViewController: UIViewController {
 
         installTextStub(self.installTextStubSwitch)
         installImageStub(self.installImageStubSwitch)
-        OHHTTPStubs.onStubActivation { (request: NSURLRequest, stub: OHHTTPStubsDescriptor, response: OHHTTPStubsResponse) in
-            print("[OHHTTPStubs] Request to \(request.URL!) has been stubbed with \(stub.name)")
+        OHHTTPStubs.onStubActivation { (request: URLRequest, stub: OHHTTPStubsDescriptor, response: OHHTTPStubsResponse) in
+            print("[OHHTTPStubs] Request to \(request.url!) has been stubbed with \(stub.name)")
         }
     }
 
     ////////////////////////////////////////////////////////////////////////////////
     // MARK: - Global stubs activation
 
-    @IBAction func toggleStubs(sender: UISwitch) {
-        OHHTTPStubs.setEnabled(sender.on)
-        self.delaySwitch.enabled = sender.on
-        self.installTextStubSwitch.enabled = sender.on
-        self.installImageStubSwitch.enabled = sender.on
+    @IBAction func toggleStubs(_ sender: UISwitch) {
+        OHHTTPStubs.setEnabled(sender.isOn)
+        self.delaySwitch.isEnabled = sender.isOn
+        self.installTextStubSwitch.isEnabled = sender.isOn
+        self.installImageStubSwitch.isEnabled = sender.isOn
         
-        let state = sender.on ? "and enabled" : "but disabled"
+        let state = sender.isOn ? "and enabled" : "but disabled"
         print("Installed (\(state)) stubs: \(OHHTTPStubs.allStubs)")
     }
     
@@ -52,30 +52,30 @@ class MainViewController: UIViewController {
     // MARK: - Text Download and Stub
     
     
-    @IBAction func downloadText(sender: UIButton) {
-        sender.enabled = false
+    @IBAction func downloadText(_ sender: UIButton) {
+        sender.isEnabled = false
         self.textView.text = nil
         
         let urlString = "http://www.opensource.apple.com/source/Git/Git-26/src/git-htmldocs/git-commit.txt?txt"
-        let req = NSURLRequest(URL: NSURL(string: urlString)!)
+        let req = URLRequest(url: URL(string: urlString)!)
 
-        NSURLConnection.sendAsynchronousRequest(req, queue: NSOperationQueue.mainQueue()) { (_, data, _) in
-            sender.enabled = true
-            if let receivedData = data, receivedText = NSString(data: receivedData, encoding: NSASCIIStringEncoding) {
+        NSURLConnection.sendAsynchronousRequest(req, queue: OperationQueue.main) { (_, data, _) in
+            sender.isEnabled = true
+            if let receivedData = data, let receivedText = NSString(data: receivedData, encoding: String.Encoding.ascii.rawValue) {
                 self.textView.text = receivedText as String
             }
         }
     }
 
     weak var textStub: OHHTTPStubsDescriptor?
-    @IBAction func installTextStub(sender: UISwitch) {
-        if sender.on {
+    @IBAction func installTextStub(_ sender: UISwitch) {
+        if sender.isOn {
             // Install
 
-            textStub = stub(isExtension("txt")) { _ in
-                let stubPath = OHPathForFile("stub.txt", self.dynamicType)
-                return fixture(stubPath!, headers: ["Content-Type":"text/plain"])
-                    .requestTime(self.delaySwitch.on ? 2.0 : 0.0, responseTime:OHHTTPStubsDownloadSpeedWifi)
+            textStub = stub(condition: isExtension("txt")) { _ in
+                let stubPath = OHPathForFile("stub.txt", type(of: self))
+                return fixture(filePath: stubPath!, headers: ["Content-Type":"text/plain"])
+                    .requestTime(self.delaySwitch.isOn ? 2.0 : 0.0, responseTime:OHHTTPStubsDownloadSpeedWifi)
             }
             textStub?.name = "Text stub"
         } else {
@@ -88,15 +88,15 @@ class MainViewController: UIViewController {
     ////////////////////////////////////////////////////////////////////////////////
     // MARK: - Image Download and Stub
     
-    @IBAction func downloadImage(sender: UIButton) {
-        sender.enabled = false
+    @IBAction func downloadImage(_ sender: UIButton) {
+        sender.isEnabled = false
         self.imageView.image = nil
 
         let urlString = "http://images.apple.com/support/assets/images/products/iphone/hero_iphone4-5_wide.png"
-        let req = NSURLRequest(URL: NSURL(string: urlString)!)
+        let req = URLRequest(url: URL(string: urlString)!)
 
-        NSURLConnection.sendAsynchronousRequest(req, queue: NSOperationQueue.mainQueue()) { (_, data, _) in
-            sender.enabled = true
+        NSURLConnection.sendAsynchronousRequest(req, queue: OperationQueue.main) { (_, data, _) in
+            sender.isEnabled = true
             if let receivedData = data {
                 self.imageView.image = UIImage(data: receivedData)
             }
@@ -104,14 +104,14 @@ class MainViewController: UIViewController {
     }
     
     weak var imageStub: OHHTTPStubsDescriptor?
-    @IBAction func installImageStub(sender: UISwitch) {
-        if sender.on {
+    @IBAction func installImageStub(_ sender: UISwitch) {
+        if sender.isOn {
             // Install
             
-            imageStub = stub(isExtension("png") || isExtension("jpg") || isExtension("gif")) { _ in
-                let stubPath = OHPathForFile("stub.jpg", self.dynamicType)
-                return fixture(stubPath!, headers: ["Content-Type":"image/jpeg"])
-                    .requestTime(self.delaySwitch.on ? 2.0 : 0.0, responseTime: OHHTTPStubsDownloadSpeedWifi)
+            imageStub = stub(condition: isExtension("png") || isExtension("jpg") || isExtension("gif")) { _ in
+                let stubPath = OHPathForFile("stub.jpg", type(of: self))
+                return fixture(filePath: stubPath!, headers: ["Content-Type":"image/jpeg"])
+                    .requestTime(self.delaySwitch.isOn ? 2.0 : 0.0, responseTime: OHHTTPStubsDownloadSpeedWifi)
             }
             imageStub?.name = "Image stub"
         } else {

--- a/Examples/Swift/MainViewController.swift
+++ b/Examples/Swift/MainViewController.swift
@@ -29,7 +29,7 @@ class MainViewController: UIViewController {
         installTextStub(self.installTextStubSwitch)
         installImageStub(self.installImageStubSwitch)
         OHHTTPStubs.onStubActivation { (request: URLRequest, stub: OHHTTPStubsDescriptor, response: OHHTTPStubsResponse) in
-            print("[OHHTTPStubs] Request to \(request.url!) has been stubbed with \(stub.name)")
+            print("[OHHTTPStubs] Request to \(request.url!) has been stubbed with \(String(describing: stub.name))")
         }
     }
 

--- a/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
+++ b/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -334,7 +334,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -351,7 +351,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -366,7 +365,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
+++ b/Examples/Swift/OHHTTPStubsDemo.xcodeproj/project.pbxproj
@@ -145,11 +145,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = AliSoftware;
 				TargetAttributes = {
 					099F74061AE2D049001108A5 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -261,8 +262,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -308,8 +311,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -328,6 +333,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -338,12 +344,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FE789C901264C7AF3BDF48CB /* Pods-OHHTTPStubsDemo.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -351,12 +359,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0BFB1DB3496791F522727353 /* Pods-OHHTTPStubsDemo.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alisoftware.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Examples/Swift/OHHTTPStubsDemo.xcodeproj/xcshareddata/xcschemes/OHHTTPStubsDemo.xcscheme
+++ b/Examples/Swift/OHHTTPStubsDemo.xcodeproj/xcshareddata/xcschemes/OHHTTPStubsDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/Swift/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Swift/Pods/Pods.xcodeproj/project.pbxproj
@@ -534,39 +534,6 @@
 			};
 			name = Debug;
 		};
-		1F8938446A84B05547A37A8503A9FE99 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E56DE22A0F090D8C9CBFEA942214081F /* OHHTTPStubs.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/OHHTTPStubs/OHHTTPStubs-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/OHHTTPStubs/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/OHHTTPStubs/OHHTTPStubs.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = OHHTTPStubs;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		397F6012FCF1132BC454B8AD3E52A2EE /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8538626B48EE5872A21F58430C92C3DD /* Pods-OHHTTPStubsDemo.release.xcconfig */;
@@ -642,7 +609,7 @@
 			};
 			name = Release;
 		};
-		6F5276603B26AC39E73B4C2CBA8D1725 /* Release */ = {
+		54EBC4B82A1DF9785C89E50F8545B8AF /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E56DE22A0F090D8C9CBFEA942214081F /* OHHTTPStubs.xcconfig */;
 			buildSettings = {
@@ -667,7 +634,7 @@
 				PRODUCT_NAME = OHHTTPStubs;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -710,6 +677,39 @@
 			};
 			name = Debug;
 		};
+		D6B4E4C994A1C84CC27DBED78C031D63 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E56DE22A0F090D8C9CBFEA942214081F /* OHHTTPStubs.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/OHHTTPStubs/OHHTTPStubs-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/OHHTTPStubs/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/OHHTTPStubs/OHHTTPStubs.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = OHHTTPStubs;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -725,8 +725,8 @@
 		67D196FE8224D50F7BC173969AE60562 /* Build configuration list for PBXNativeTarget "OHHTTPStubs" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1F8938446A84B05547A37A8503A9FE99 /* Debug */,
-				6F5276603B26AC39E73B4C2CBA8D1725 /* Release */,
+				D6B4E4C994A1C84CC27DBED78C031D63 /* Debug */,
+				54EBC4B82A1DF9785C89E50F8545B8AF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -1319,7 +1319,7 @@
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -1359,7 +1359,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MODULEMAP_FILE = "$(SRCROOT)/Supporting Files/module.modulemap";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -70,9 +70,15 @@
  * - Returns: The `OHHTTPStubsResponse` instance that will stub with the given status code
  *            & headers, and use the file content as the response body.
  */
+#if swift(>=3.0)
+public func fixture(filePath: String, status: Int32 = 200, headers: [AnyHashable: Any]?) -> OHHTTPStubsResponse {
+    return OHHTTPStubsResponse(fileAtPath: filePath, statusCode: status, headers: headers)
+}
+#else
 public func fixture(filePath: String, status: Int32 = 200, headers: [NSObject: AnyObject]?) -> OHHTTPStubsResponse {
     return OHHTTPStubsResponse(fileAtPath: filePath, statusCode: status, headers: headers)
 }
+#endif
 
 /**
  * Helper to call the stubbing function in a more concise way?

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -138,7 +138,7 @@ class SwiftHelpersTests : XCTestCase {
       let req = NSURLRequest(URL: NSURL(string: url)!)
 #endif
       let p = req.url?.path
-      print("URL: \(url) -> Path: \(p)")
+      print("URL: \(url) -> Path: \(String(reflecting: p))")
       XCTAssert(matcher(req) == result, "isPath(\"\(path)\" matcher failed when testing url \(url)")
     }
   }
@@ -187,7 +187,7 @@ class SwiftHelpersTests : XCTestCase {
       let req = NSURLRequest(URL: NSURL(string: url)!)
 #endif
       let p = req.url?.path
-      print("URL: \(url) -> Path: \(p)")
+      print("URL: \(url) -> Path: \(String(reflecting: p))")
       XCTAssert(matcher(req) == result, "pathStartsWith(\"\(path)\" matcher failed when testing url \(url)")
     }
   }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ OHHTTPStubs
 [![Version](http://cocoapod-badges.herokuapp.com/v/OHHTTPStubs/badge.png)](http://cocoadocs.org/docsets/OHHTTPStubs)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Build Status](https://travis-ci.org/AliSoftware/OHHTTPStubs.svg?branch=master)](https://travis-ci.org/AliSoftware/OHHTTPStubs)
+[![Language: Swift 3.1](https://img.shields.io/badge/Swift-3.1-orange.svg)](https://swift.org)
 
 `OHHTTPStubs` is a library designed to stub your network requests very easily. It can help you:
 


### PR DESCRIPTION
This pull request is mostly a merge of the `swift-3.0` branch to implement #233 :
- it makes `master` use Swift 3.0 as default.
- it fixes some string warnings in some logs from Xcode 8.3.

Once this is merged we will create a `swift-2.3` branch to allow users to use the legacy Swift version if they need it.

❓~One thing I am wondering is if the Travis CI configuration should not be updated in this PR to test both Xcode 8.3 and Xcode 8.2?
Maybe at least change the `osx_image` to `xcode8.3` instead of `xcode8` which from [travis' documentation](https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version) targets some Xcode 8 GM~ 🙄 
The build matrix has been updated to use Xcode 8.3.

A language badge has been added to the [`README`](https://github.com/AliSoftware/OHHTTPStubs/blob/000b57e27adc772ed7d13fb5e3319c2f72d9ca3b/README.md) file. [![Language: Swift 3.1](https://img.shields.io/badge/Swift-3.1-orange.svg)](https://swift.org)
