### PR TITLE
Add precondition assertions in scheme, host matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OHHTTPStubs — CHANGELOG
 
+## Master
+
+* Add precondition assertions in `isScheme` and `isHost` matchers and some documentation in `isHost`, `isScheme` and `isPath`.  
+  [@Liquidsoul](https://github.com/Liquidsoul)
+  [#248](https://github.com/AliSoftware/OHHTTPStubs/pull/248)
+
 ## [6.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/6.0.0)
 
 * Made Swift 3 the default. `master` is now compatible with 3.0 and 3.1.  

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -154,29 +154,38 @@ public func isMethodDELETE() -> OHHTTPStubsTestBlock {
 /**
  * Matcher for testing an `NSURLRequest`'s **scheme**.
  *
+ * e.g. the scheme part is `https` in `https://api.example.com/signin`
+ *
  * - Parameter scheme: The scheme to match
  *
  * - Returns: a matcher (OHHTTPStubsTestBlock) that succeeds only if the request
  *            has the given scheme
  */
 public func isScheme(_ scheme: String) -> OHHTTPStubsTestBlock {
+  precondition(!scheme.contains("://"), "The scheme part of an URL never contains '://'. Only use strings like 'https' for this value, and not things like 'https://'")
+  precondition(!scheme.contains("/"), "The scheme part of an URL never contains any slash. Only use strings like 'https' for this value, and not things like 'https://api.example.com/'")
   return { req in req.url?.scheme == scheme }
 }
 
 /**
  * Matcher for testing an `NSURLRequest`'s **host**.
  *
- * - Parameter host: The host to match
+ * e.g. the host part is `api.example.com` in `https://api.example.com/signin`.
+ *
+ * - Parameter host: The host to match (e.g. 'api.example.com')
  *
  * - Returns: a matcher (OHHTTPStubsTestBlock) that succeeds only if the request
  *            has the given host
  */
 public func isHost(_ host: String) -> OHHTTPStubsTestBlock {
+  precondition(!host.contains("/"), "The host part of an URL never contains any slash. Only use strings like 'api.example.com' for this value, and not things like 'https://api.example.com/'")
   return { req in req.url?.host == host }
 }
 
 /**
  * Matcher for testing an `NSURLRequest`'s **path**.
+ *
+ * e.g. the path is `/signin` in `https://api.example.com/signin`.
  *
  * - Parameter path: The path to match
  *

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -55,7 +55,7 @@
 
   extension String {
     private func contains(string: String) -> Bool {
-      return (self as NSString).containsString(string)
+      return rangeOfString(string) != nil
     }
   }
 #endif

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -52,6 +52,12 @@
       return valueForHTTPHeaderField(key)
     }
   }
+
+  extension String {
+    private func contains(string: String) -> Bool {
+      return (self as NSString).containsString(string)
+    }
+  }
 #endif
 
 


### PR DESCRIPTION
Also added an explanation of which part it is in an example URL.

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Add preconditions so that user are better informed of why their requests are not stubbed.
This also adds information of what is a scheme, host or path in the documentation of each matcher.

### Motivation and Context

This will help users see why their matchers setup does not work (see #247).