### PR TITLE
In Test cases, Fix potential memory leaks by use of NSURLSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # OHHTTPStubs — CHANGELOG
 
 ## Master
-* Fixed potential memory leaks with use of NSURLSession as detected by our devs.
+* Fixed potential memory leaks with use of NSURLSession as detected by our devs.  
   [@mikelupo](https://github.com/mikelupo
-  [#249](https://github.com/AliSoftware/OHHTTPStubs/pull/249)
+  [#250](https://github.com/AliSoftware/OHHTTPStubs/pull/250)
 * Add precondition assertions in `isScheme` and `isHost` matchers and some documentation in `isHost`, `isScheme` and `isPath`.  
   [@Liquidsoul](https://github.com/Liquidsoul)
   [#248](https://github.com/AliSoftware/OHHTTPStubs/pull/248)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # OHHTTPStubs — CHANGELOG
 
 ## Master
-
+* Fixed potential memory leaks with use of NSURLSession as detected by our devs.
+  [@mikelupo](https://github.com/mikelupo
+  [#249](https://github.com/AliSoftware/OHHTTPStubs/pull/249)
 * Add precondition assertions in `isScheme` and `isHost` matchers and some documentation in `isHost`, `isScheme` and `isPath`.  
   [@Liquidsoul](https://github.com/Liquidsoul)
   [#248](https://github.com/AliSoftware/OHHTTPStubs/pull/248)

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -45,7 +45,7 @@
 {
     [super setUp];
     [OHHTTPStubs removeAllStubs];
-    
+
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     self.session = [NSURLSession sessionWithConfiguration:configuration delegate:nil delegateQueue:nil];
 }
@@ -53,6 +53,7 @@
 - (void)tearDown
 {
     [super tearDown];
+    [self.session invalidateAndCancel];
     self.session = nil;
 }
 
@@ -110,18 +111,18 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:60.0];
-    
+
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    
+
     request.HTTPMethod = @"POST";
     NSDictionary *mapData = @{@"iloveit": @"happyuser1",
                              @"password": @"username"};
     NSData *postData = [NSJSONSerialization dataWithJSONObject:mapData options:0 error:NULL];
     request.HTTPBody = postData;
-    
+
     XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-    
+
     __block NSHTTPURLResponse *capturedResponse;
     NSURLSessionDataTask *postDataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) capturedResponse = (id)response;
@@ -131,18 +132,18 @@
         {
             json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         }
-        
+
         XCTAssertNotNil(json, @"The response is not a json object");
         XCTAssertEqualObjects(json[@"status"], @"SUCCESS", @"The response does to return a successful status");
         XCTAssertNotNil(json[@"user_token"], @"The response does not contain a user token");
-        
+
         [expectation fulfill];
     }];
-    
+
     [postDataTask resume];
-    
+
     [self waitForExpectationsWithTimeout:10 handler:nil];
-    
+
     return capturedResponse;
 }
 
@@ -152,36 +153,36 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:60.0];
-    
+
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    
+
     request.HTTPMethod = @"GET";
-    
+
     XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-    
+
     __block NSHTTPURLResponse *capturedResponse;
     NSURLSessionDataTask *getDataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) capturedResponse = (id)response;
         XCTAssertNil(error, @"Error while getting cards.");
-        
+
         NSArray *json = nil;
         if(!error && [@"application/json" isEqual:response.MIMEType])
         {
             json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         }
-        
+
         XCTAssertNotNil(json, @"The response is not a json object");
         XCTAssertEqual(json.count, 2, @"The response does not contain 2 cards");
         XCTAssertEqualObjects([json firstObject][@"amount"], @"$25.28", @"The first card amount does not match");
-        
+
         [expectation fulfill];
     }];
-    
+
     [getDataTask resume];
-    
+
     [self waitForExpectationsWithTimeout:10 handler:nil];
-    
+
     return capturedResponse;
 }
 

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -45,7 +45,7 @@
 {
     [super setUp];
     [OHHTTPStubs removeAllStubs];
-
+    
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     self.session = [NSURLSession sessionWithConfiguration:configuration delegate:nil delegateQueue:nil];
 }
@@ -111,18 +111,18 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:60.0];
-
+    
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
-
+    
     request.HTTPMethod = @"POST";
     NSDictionary *mapData = @{@"iloveit": @"happyuser1",
                              @"password": @"username"};
     NSData *postData = [NSJSONSerialization dataWithJSONObject:mapData options:0 error:NULL];
     request.HTTPBody = postData;
-
+    
     XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-
+    
     __block NSHTTPURLResponse *capturedResponse;
     NSURLSessionDataTask *postDataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) capturedResponse = (id)response;
@@ -132,18 +132,18 @@
         {
             json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         }
-
+        
         XCTAssertNotNil(json, @"The response is not a json object");
         XCTAssertEqualObjects(json[@"status"], @"SUCCESS", @"The response does to return a successful status");
         XCTAssertNotNil(json[@"user_token"], @"The response does not contain a user token");
-
+        
         [expectation fulfill];
     }];
-
+    
     [postDataTask resume];
-
+    
     [self waitForExpectationsWithTimeout:10 handler:nil];
-
+    
     return capturedResponse;
 }
 
@@ -153,34 +153,34 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:60.0];
-
+    
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
-
+    
     request.HTTPMethod = @"GET";
-
+    
     XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-
+    
     __block NSHTTPURLResponse *capturedResponse;
     NSURLSessionDataTask *getDataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) capturedResponse = (id)response;
         XCTAssertNil(error, @"Error while getting cards.");
-
+        
         NSArray *json = nil;
         if(!error && [@"application/json" isEqual:response.MIMEType])
         {
             json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         }
-
+        
         XCTAssertNotNil(json, @"The response is not a json object");
         XCTAssertEqual(json.count, 2, @"The response does not contain 2 cards");
         XCTAssertEqualObjects([json firstObject][@"amount"], @"$25.28", @"The first card amount does not match");
-
+        
         [expectation fulfill];
     }];
-
+    
     [getDataTask resume];
-
+    
     [self waitForExpectationsWithTimeout:10 handler:nil];
     
     return capturedResponse;

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -182,7 +182,7 @@
     [getDataTask resume];
 
     [self waitForExpectationsWithTimeout:10 handler:nil];
-
+    
     return capturedResponse;
 }
 

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
@@ -64,23 +64,23 @@
     {
         static const NSTimeInterval kRequestTime = 0.0;
         static const NSTimeInterval kResponseTime = 0.2;
-        
+
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
         } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
             return [[OHHTTPStubsResponse responseWithJSONObject:json statusCode:200 headers:nil]
                     requestTime:kRequestTime responseTime:kResponseTime];
         }];
-        
+
         XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-        
+
         __block __strong id dataResponse = nil;
         __block __strong NSError* errorResponse = nil;
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"foo://unknownhost:666"]];
         request.HTTPMethod = @"GET";
         [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
         [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-        
+
         NSURLSessionDataTask *task =  [session dataTaskWithRequest:request
                                                  completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
         {
@@ -96,7 +96,7 @@
         }];
 
         [task resume];
-        
+
         [self waitForExpectationsWithTimeout:kRequestTime+kResponseTime+0.5 handler:^(NSError * _Nullable error) {
             completion(errorResponse, dataResponse);
         }];
@@ -183,7 +183,7 @@
     if ([NSURLSession class])
     {
         NSURLSession *session = [NSURLSession sharedSession];
-        
+
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -195,6 +195,8 @@
             XCTAssertNil(redirectResponse, @"Unexpected redirect response received");
             XCTAssertEqualObjects(jsonResponse, json, @"Unexpected data received");
         }];
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -208,7 +210,7 @@
     {
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-        
+
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -220,6 +222,8 @@
             XCTAssertNil(redirectResponse, @"Unexpected redirect response received");
             XCTAssertEqualObjects(jsonResponse, json, @"Unexpected data received");
         }];
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -243,6 +247,7 @@
             XCTAssertEqual(301, [redirectResponse statusCode], @"Expected 301 redirect");
             XCTAssertNil(jsonResponse, @"Unexpected data received");
         }];
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -256,7 +261,7 @@
     {
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-        
+
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -268,6 +273,8 @@
             XCTAssertNil(redirectResponse, @"Unexpected redirect response received");
             XCTAssertEqualObjects(jsonResponse, json, @"Unexpected data received");
         }];
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -282,7 +289,7 @@
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         [OHHTTPStubs setEnabled:NO forSessionConfiguration:config]; // Disable stubs for this session
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-        
+
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             // Stubs were disable for this session, so we should get an error instead of the stubs data
@@ -296,6 +303,8 @@
             XCTAssertNil(redirectResponse, @"Redirect response should not have been received as stubs should be disabled");
             XCTAssertNil(jsonResponse, @"Data should not have been received as stubs should be disabled");
         }];
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -314,16 +323,16 @@
             return [[OHHTTPStubsResponse responseWithData:expectedResponse statusCode:200 headers:nil]
                     responseTime:0.5];
         }];
-        
+
         _taskDidCompleteExpectation = [self expectationWithDescription:@"NSURLSessionDataTask completion delegate method called"];
-        
+
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSURLSession* session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
-        
+
         [[session dataTaskWithURL:[NSURL URLWithString:@"stub://foo"]] resume];
-        
+
         [self waitForExpectationsWithTimeout:5 handler:nil];
-        
+
         XCTAssertEqualObjects(_receivedData, expectedResponse, @"Unexpected response");
     }
     else
@@ -366,6 +375,7 @@
 
         requestWithBody.HTTPBody = [@"somethingElse" dataUsingEncoding:NSUTF8StringEncoding];
         [[session dataTaskWithRequest:requestWithBody] resume];
+		[session finishTasksAndInvalidate];
 
         [self waitForExpectationsWithTimeout:5 handler:nil];
 

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
@@ -64,23 +64,23 @@
     {
         static const NSTimeInterval kRequestTime = 0.0;
         static const NSTimeInterval kResponseTime = 0.2;
-
+        
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return YES;
         } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
             return [[OHHTTPStubsResponse responseWithJSONObject:json statusCode:200 headers:nil]
                     requestTime:kRequestTime responseTime:kResponseTime];
         }];
-
+        
         XCTestExpectation* expectation = [self expectationWithDescription:@"NSURLSessionDataTask completed"];
-
+        
         __block __strong id dataResponse = nil;
         __block __strong NSError* errorResponse = nil;
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"foo://unknownhost:666"]];
         request.HTTPMethod = @"GET";
         [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
         [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-
+        
         NSURLSessionDataTask *task =  [session dataTaskWithRequest:request
                                                  completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
         {
@@ -96,7 +96,7 @@
         }];
 
         [task resume];
-
+        
         [self waitForExpectationsWithTimeout:kRequestTime+kResponseTime+0.5 handler:^(NSError * _Nullable error) {
             completion(errorResponse, dataResponse);
         }];
@@ -183,7 +183,7 @@
     if ([NSURLSession class])
     {
         NSURLSession *session = [NSURLSession sharedSession];
-
+        
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -210,7 +210,7 @@
     {
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-
+        
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -247,6 +247,7 @@
             XCTAssertEqual(301, [redirectResponse statusCode], @"Expected 301 redirect");
             XCTAssertNil(jsonResponse, @"Unexpected data received");
         }];
+
         [session finishTasksAndInvalidate];
     }
     else
@@ -261,7 +262,7 @@
     {
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-
+        
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             XCTAssertNil(errorResponse, @"Unexpected error");
@@ -289,7 +290,7 @@
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         [OHHTTPStubs setEnabled:NO forSessionConfiguration:config]; // Disable stubs for this session
         NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
-
+        
         NSDictionary* json = @{@"Success": @"Yes"};
         [self _test_NSURLSession:session jsonForStub:json completion:^(NSError *errorResponse, id jsonResponse) {
             // Stubs were disable for this session, so we should get an error instead of the stubs data
@@ -323,17 +324,19 @@
             return [[OHHTTPStubsResponse responseWithData:expectedResponse statusCode:200 headers:nil]
                     responseTime:0.5];
         }];
-
+        
         _taskDidCompleteExpectation = [self expectationWithDescription:@"NSURLSessionDataTask completion delegate method called"];
-
+        
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
         NSURLSession* session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
-
+        
         [[session dataTaskWithURL:[NSURL URLWithString:@"stub://foo"]] resume];
-
+        
         [self waitForExpectationsWithTimeout:5 handler:nil];
-
+        
         XCTAssertEqualObjects(_receivedData, expectedResponse, @"Unexpected response");
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -375,11 +378,12 @@
 
         requestWithBody.HTTPBody = [@"somethingElse" dataUsingEncoding:NSUTF8StringEncoding];
         [[session dataTaskWithRequest:requestWithBody] resume];
-        [session finishTasksAndInvalidate];
 
         [self waitForExpectationsWithTimeout:5 handler:nil];
 
         XCTAssertNil(_receivedData, @"Unexpected response: HTTP body check should not be successful");
+
+        [session finishTasksAndInvalidate];
     }
     else
     {
@@ -413,6 +417,8 @@
 
         [self waitForExpectationsWithTimeout:5 handler:nil];
         XCTAssertNil(_receivedData, @"[request HTTPBody] is not expected to work. If this has been fixed, the OHHTTPStubs_HTTPBody can be removed.");
+
+        [session finishTasksAndInvalidate];
     }
     else
     {

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
@@ -375,7 +375,7 @@
 
         requestWithBody.HTTPBody = [@"somethingElse" dataUsingEncoding:NSUTF8StringEncoding];
         [[session dataTaskWithRequest:requestWithBody] resume];
-		[session finishTasksAndInvalidate];
+        [session finishTasksAndInvalidate];
 
         [self waitForExpectationsWithTimeout:5 handler:nil];
 


### PR DESCRIPTION
NSURLSession documentation states:
“Important: The session object keeps a strong reference
to the delegate until your app explicitly invalidates the
session. If you do not invalidate the session, your app
leaks memory.”

http://tinyurl.com/jnb6642

<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [ X ] I've checked that all new and existing tests pass
- [N/A] I've updated the documentation if necessary
- [ X] I've added an entry in the CHANGELOG to credit myself

### Description

<!--- Describe your changes in detail -->
NSURLSessions can leak according to the Apple docs. So I've fixed the tests that use them.
Fixed a test that was failing (not due to my changes). "Task created in a session that has been invalidated"

I've removed some invalid whitespace (caught by our own Gerrit). 
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Memory leaks which can contribute to unexpected and hard to diagnose improper test behavior.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I ran the tests in XCode. Passing 100%.