### PR TITLE
Feature/259 urlrequest httpbody function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # OHHTTPStubs — CHANGELOG
 
 ## Master
+* Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.
+  [@mplorentz](https://github.com/mplorentz)
 * Added absolute url matcher.  
   [@victorg1991](https://github.com/victorg1991)
   [#254](https://github.com/AliSoftware/OHHTTPStubs/pull/254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # OHHTTPStubs — CHANGELOG
 
 ## Master
-* Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.
+
+* Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.  
   [@mplorentz](https://github.com/mplorentz)
 * Added absolute url matcher.  
   [@victorg1991](https://github.com/victorg1991)

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -58,6 +58,12 @@
       return rangeOfString(string) != nil
     }
   }
+#else
+  extension URLRequest {
+    public var ohhttpStubs_httpBody: Data? {
+      return (self as NSURLRequest).ohhttpStubs_HTTPBody()
+    }
+  }
 #endif
 
 

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -446,9 +446,9 @@ class SwiftHelpersTests : XCTestCase {
     req.httpBody = Data()
     XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
 #else
-    let req = NSURLRequest(URL: NSURL(string: "foo://bar")!)
+    let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
     req.HTTPBody = NSData()
-    XCTAssert(req.OHHTTPStubs_HTTPBody() == req.httpBody)
+    XCTAssert(req.OHHTTPStubs_HTTPBody() == req.HTTPBody)
 #endif
   }
 

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -443,13 +443,13 @@ class SwiftHelpersTests : XCTestCase {
   func test_ohhttpStubs_httpBody() {
 #if swift(>=3.0)
     var req = URLRequest(url: URL(string: "foo://bar")!)
+    req.httpBody = Data()
+    XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
 #else
     let req = NSURLRequest(URL: NSURL(string: "foo://bar")!)
+    req.HTTPBody = NSData()
+    XCTAssert(req.OHHTTPStubs_HTTPBody() == req.httpBody)
 #endif
-
-    req.httpBody = Data()
-        
-    XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
   }
 
   let sampleURLs = [

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -442,13 +442,15 @@ class SwiftHelpersTests : XCTestCase {
     
   func test_ohhttpStubs_httpBody() {
 #if swift(>=3.0)
+    let data = "Hello world".data(using: .utf8)
     var req = URLRequest(url: URL(string: "foo://bar")!)
-    req.httpBody = Data()
-    XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
+    req.httpBody = data
+    XCTAssertEqual(req.ohhttpStubs_httpBody, data)
 #else
+    let data = "Hello world".dataUsingEncoding(NSUTF8StringEncoding)
     let req = NSMutableURLRequest(URL: NSURL(string: "foo://bar")!)
-    req.HTTPBody = NSData()
-    XCTAssert(req.OHHTTPStubs_HTTPBody() == req.HTTPBody)
+    req.HTTPBody = data
+    XCTAssertEqual(req.OHHTTPStubs_HTTPBody(), data)
 #endif
   }
 

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -439,6 +439,18 @@ class SwiftHelpersTests : XCTestCase {
 
     XCTAssertFalse(matchesHeader)
   }
+    
+  func test_ohhttpStubs_httpBody() {
+#if swift(>=3.0)
+    var req = URLRequest(url: URL(string: "foo://bar")!)
+#else
+    let req = NSURLRequest(URL: NSURL(string: "foo://bar")!)
+#endif
+
+    req.httpBody = Data()
+        
+    XCTAssert(req.ohhttpStubs_httpBody == req.httpBody)
+  }
 
   let sampleURLs = [
     // Absolute URLs


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Fixed the URLRequest.ohhttpStubs_httpBody in Swift 3 and 4.

### Motivation and Context

Fixes #259 and allows users to make assertions on the HTTP POST body of a `URLRequest` in `OHHTTPStubsTestBlock`s and `OHHTTPStubsResponseBlock`s.

Sorry about the sloppy commits. I didn't want to download Xcode 7 again so I did a little guess and check with Travis.