### PR TITLE
Add onStubMissing to report missing stubs; detects "stale" stubs which can lead to intermittent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-* Added `onStubMissing` to report missing stubs
+* Added `onStubMissing` to report missing stubs.  
   [@c1ira](https://github.com/c1ira)
 * Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.  
   [@mplorentz](https://github.com/mplorentz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `onStubMissing` to report missing stubs.  
   [@c1ira](https://github.com/c1ira)
+  [#264](https://github.com/AliSoftware/OHHTTPStubs/pull/264)
 * Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.  
   [@mplorentz](https://github.com/mplorentz)
 * Added absolute url matcher.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* Added `onStubMissing` to report missing stubs
+  [@c1ira](https://github.com/c1ira)
 * Fixed `URLRequest.ohhttpStubs_httpBody` function in Swift 3 and 4.  
   [@mplorentz](https://github.com/mplorentz)
 * Added absolute url matcher.  

--- a/OHHTTPStubs/Sources/OHHTTPStubs.h
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.h
@@ -205,6 +205,14 @@ typedef OHHTTPStubsResponse* __nonnull (^OHHTTPStubsResponseBlock)( NSURLRequest
  */
 +(void)afterStubFinish:( nullable void(^)(NSURLRequest* request, id<OHHTTPStubsDescriptor> stub, OHHTTPStubsResponse* responseStub, NSError *error) )block;
 
+/**
+ *  Setup a block to be called whenever OHHTTPStubs encounters a missing stub.
+ *
+ *  @param block The block to call each time no stub for a request can be found.
+ *               Set it to `nil` to do nothing. Defaults is `nil`.
+ */
++(void)onStubMissing:( nullable void(^)(NSURLRequest* request) )block;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Add onStubMissing to report missing stubs; detects "stale" stubs which can lead to intermittent failures.

### Motivation and Context

We've been using a fork with this change at Capital One for several months. It's been a big help in solving previously mysterious test failures, where if a stub was missing a request would go to a live server with inconsistent results. It has also helped us visualize our API usage in a different way, for example noticing when a request is made only intermittently or under specific conditions.

Tested by... a) Using it at Capital One for several months, getting hit hundreds, if not thousands, of times per day. b) Ran existing unit tests, and they all passed. c) Did not add a unit test for this feature, since didn't see unit tests for the other debug blocks.