### PR TITLE
Add matcher "hasJsonBody"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* Added `hasJsonBody(_:)` matcher.  
+  [@pimnijman](https://github.com/pimnijman)
 * Added `onStubMissing` to report missing stubs.  
   [@c1ira](https://github.com/c1ira)
   [#264](https://github.com/AliSoftware/OHHTTPStubs/pull/264)

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -401,7 +401,10 @@ public func hasHeaderNamed(_ name: String, value: String) -> OHHTTPStubsTestBloc
 #if swift(>=3.0)
 public func hasJsonBody(_ jsonObject: [AnyHashable : Any]) -> OHHTTPStubsTestBlock {
   return { req in
-    guard let jsonBody = (try? JSONSerialization.jsonObject(with: (req as NSURLRequest).ohhttpStubs_HTTPBody(), options: [])) as? [AnyHashable : Any] else {
+    guard
+      let httpBody = req.ohhttpStubs_httpBody,
+      let jsonBody = (try? JSONSerialization.jsonObject(with: httpBody, options: [])) as? [AnyHashable : Any]
+    else {
       return false
     }
     return NSDictionary(dictionary: jsonBody).isEqual(to: jsonObject)

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -392,6 +392,23 @@ public func hasHeaderNamed(_ name: String, value: String) -> OHHTTPStubsTestBloc
   }
 #endif
 
+/**
+ * Matcher testing that the `NSURLRequest` body contains a JSON object with the same keys and values
+ * - Parameter jsonObject: the JSON object to expect
+ *
+ * - Returns: a matcher that returns true if the `NSURLRequest`'s body contains a JSON object with the same keys and values as the parameter value
+ */
+#if swift(>=3.0)
+public func hasJsonBody(_ jsonObject: [AnyHashable : Any]) -> OHHTTPStubsTestBlock {
+  return { req in
+    guard let jsonBody = (try? JSONSerialization.jsonObject(with: (req as NSURLRequest).ohhttpStubs_HTTPBody(), options: [])) as? [AnyHashable : Any] else {
+      return false
+    }
+    return NSDictionary(dictionary: jsonBody).isEqual(to: jsonObject)
+  }
+}
+#endif
+
 // MARK: Operators on OHHTTPStubsTestBlock
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

<!--- Describe your changes in detail -->
I've added a matcher called `hasJsonBody` that  tests whether the `NSURLRequest` body contains a JSON object with the same keys and values.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Since it shouldn't matter in what way the attributes of a JSON object are ordered, trying to match the URL request's body using `hasBody` isn't very handy when it comes to verifying JSON content. That is why I've created a matcher that takes a JSON object and matches is with whatever JSON object it can find in the URL request's body.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
I've added two methods in `SwiftHelpersTests.swift` that test a handful of scenarios. Please check them out and let me know if you think I overlooked some important scenarios
