### PR TITLE
containsAtLeastQueryParams: A matcher that checks only the target params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OHHTTPStubs — CHANGELOG
 
+## [6.1.1](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/6.1.1)
+
+* Added `containsAtLeastQueryParams` matcher.  
+  [@crsantos](https://github.com/crsantos)
+  
 ## [6.1.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/6.1.0)
 
 * Updated deployment target for the pod to 7.0 to remove warning for old APIs.  

--- a/OHHTTPStubs.podspec
+++ b/OHHTTPStubs.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "OHHTTPStubs"
-  s.version      = "6.1.0"
+  s.version      = "6.1.1"
 
   s.summary      = "Framework to stub your network requests like HTTP and help you write network unit tests with XCTest."
   s.description  = <<-DESC.gsub(/^ +\|/,'')

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -350,6 +350,34 @@ public func containsQueryParams(_ params: [String:String?]) -> OHHTTPStubsTestBl
   }
 }
 
+/** // TODO update docs
+ * Matcher for testing an `NSURLRequest`'s **query parameters**.
+ *
+ * - Parameter params: The dictionary of query parameters to check the presence for
+ *
+ * - Returns: a matcher (OHHTTPStubsTestBlock) that succeeds if the request contains
+ *            the given query parameters with the given value.
+ *
+ * - Note: There is a difference between:
+ *          (1) using `[q:""]`, which matches a query parameter "?q=" with an empty value, and
+ *          (2) using `[q:nil]`, which matches a query parameter "?q" without a value at all
+ */
+@available(iOS 8.0, OSX 10.10, *)
+public func containsAtLeastQueryParams(_ params: [String:String?]) -> OHHTTPStubsTestBlock {
+    return { req in
+        if let url = req.url {
+            let comps = NSURLComponents(url: url, resolvingAgainstBaseURL: true)
+            if let queryItems = comps?.queryItems {
+                for (k,v) in params {
+                    if queryItems.filter({ qi in qi.name == k && qi.value == v }).count == 0 { return false }
+                }
+                return true
+            }
+        }
+        return false
+    }
+}
+
 /**
  * Matcher testing that the `NSURLRequest` headers contain a specific key
  * - Parameter name: the name of the key to search for in the `NSURLRequest`'s **allHTTPHeaderFields** property

--- a/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
+++ b/OHHTTPStubs/Sources/Swift/OHHTTPStubsSwift.swift
@@ -350,12 +350,12 @@ public func containsQueryParams(_ params: [String:String?]) -> OHHTTPStubsTestBl
   }
 }
 
-/** // TODO update docs
- * Matcher for testing an `NSURLRequest`'s **query parameters**.
+/**
+ * Matcher for testing an `NSURLRequest`'s target **query parameters**.
  *
- * - Parameter params: The dictionary of query parameters to check the presence for
+ * - Parameter params: The dictionary of query parameters to check the presence for, and only
  *
- * - Returns: a matcher (OHHTTPStubsTestBlock) that succeeds if the request contains
+ * - Returns: a matcher (OHHTTPStubsTestBlock) that succeeds if the request contains at least
  *            the given query parameters with the given value.
  *
  * - Note: There is a difference between:

--- a/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
+++ b/OHHTTPStubs/UnitTests/Test Suites/SwiftHelpersTests.swift
@@ -376,6 +376,39 @@ class SwiftHelpersTests : XCTestCase {
       XCTAssert(matcher(req) == result, "containsQueryParams(\"\(params)\") matcher failed when testing url \(url)")
     }
   }
+  @available(iOS 8.0, OSX 10.10, *)
+  func testContainsAtLeastQueryParams() {
+    let params: [String: String?] = ["q":"test", "lang":"en"]
+    let matcher = containsAtLeastQueryParams(params)
+
+    let urls = [
+      "foo://bar": false,
+      "foo://bar?q=test": false,
+      "foo://bar?lang=en": false,
+      "foo://bar#q=test&lang=en": false,
+      "foo://bar#lang=en&q=test": false,
+      "foo://bar;q=test&lang=en": false,
+      "foo://bar;lang=en&q=test": false,
+
+      "foo://bar?q=test&lang=en": true, // matches at least all params
+      "foo://bar?lang=en&q=test": true, // matches at least all params in any order
+      "foo://bar?q=en&lang=test": false, // param keys exist but values mismatch
+      "foo://bar?q=test&lang=en&&wizz=fuzz": true,
+      "foo://bar?wizz=fuzz&lang=en&&q=test": true,
+      "?q=test&lang=en": true,
+      "?lang=en&flag&empty=&q=test": true,
+    ]
+
+    for (url, result) in urls {
+#if swift(>=3.0)
+      let req = URLRequest(url: URL(string: url)!)
+#else
+      let req = NSURLRequest(URL: NSURL(string: url)!)
+#endif
+
+      XCTAssert(matcher(req) == result, "containsAtLeastQueryParams(\"\(params)\") matcher failed when testing url \(url)")
+    }
+  }
 
   func testHasHeaderNamedIsTrue() {
 #if swift(>=3.0)


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

This is my proposal for a matcher that checks *ONLY* the target parameters, and does not fail when more parameters are found. Just like `containsAtLeastQueryParams`, but it doesn't break when more parameters are found.

### Motivation and Context

My motivation was that I need to stub a request but I didn't want to handle all the parameters, just 2 or 3. 
So , this matches **at least** the target parameters, and ignores the others, if there are more than the target ones, ignores them, validating only the passed ones.

I don't know if I should bump spec version, if not, please say so, so I can revert.

Thanks.