### PR TITLE
Drop special headers from redirected requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## [Future release]
 * Enabled application extension API only.  
   [@lightsprint09](https://github.com/lightsprint09)
-* Disabled a flaky redirect test and adding the known issue with redirects to the README.
+* Disabled a flaky redirect test and adding the known issue with redirects to the README.  
   [@jeffctown](https://github.com/jeffctown)
   [#301](https://github.com/AliSoftware/OHHTTPStubs/pull/301)
 * Added `isMethodHEAD()` to the `Swift` helpers.  
   [@Simon-Kaz](https://github.com/Simon-Kaz)
   [#294](https://github.com/AliSoftware/OHHTTPStubs/pull/294)
 * Fixed issue with not preserving correct headers when following 3xx
-  redirects.
+  redirects.  
   [@sberrevoets](https://github.com/sberrevoets)
 
 ## [6.1.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/6.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Added `isMethodHEAD()` to the `Swift` helpers.  
   [@Simon-Kaz](https://github.com/Simon-Kaz)
   [#294](https://github.com/AliSoftware/OHHTTPStubs/pull/294)
+* Fixed issue with not preserving correct headers when following 3xx
+  redirects.
+  [@sberrevoets](https://github.com/sberrevoets)
 
 ## [6.1.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/6.1.0)
 

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -360,12 +360,12 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
 {
-	return request;
+    return request;
 }
 
 - (NSCachedURLResponse *)cachedResponse
 {
-	return nil;
+    return nil;
 }
 
 - (void)startLoading
@@ -442,13 +442,23 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
                         case 301:
                         case 302:
                         case 307:
-                        case 308:
+                        case 308: {
                             //Preserve the original request method and body, and set the new location URL
                             mReq = [self.request mutableCopy];
                             [mReq setURL:redirectLocationURL];
-                            redirectRequest = (NSURLRequest*)[mReq copy];
-                            break;
 
+                            // Drop certain headers in accordance with
+                            // https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders
+                            [mReq setValue:nil forHTTPHeaderField:@"Authorization"];
+                            [mReq setValue:nil forHTTPHeaderField:@"Connection"];
+                            [mReq setValue:nil forHTTPHeaderField:@"Host"];
+                            [mReq setValue:nil forHTTPHeaderField:@"Proxy-Authenticate"];
+                            [mReq setValue:nil forHTTPHeaderField:@"Proxy-Authorization"];
+                            [mReq setValue:nil forHTTPHeaderField:@"WWW-Authenticate"];
+                            redirectRequest = (NSURLRequest*)[mReq copy];
+
+                            break;
+                        }
                         default:
                             redirectRequest = [NSURLRequest requestWithURL:redirectLocationURL];
                             break;

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
@@ -378,11 +378,12 @@
                 NSDictionary *headers = @{
                                           @"Authorization": @"authorization",
                                           @"Connection": @"connection",
+                                          @"Preserved1": @"preserved"
                                           @"Host": @"host",
                                           @"Proxy-Authenticate": @"proxy-authenticate",
                                           @"Proxy-Authorization": @"proxy-authorization",
+                                          @"Preserved2": @"preserved",
                                           @"WWW-Authenticate": @"www-authenticate",
-                                          @"Preserved": @"preserved"
                                           };
                 [self _test_redirect_NSURLSession:session httpMethod:method headers:headers jsonBody:nil delays:0.0 redirectStatusCode:statusCode
                                        completion:^(NSString *redirectedRequestMethod, NSDictionary *redirectedRequestHeaders, id redirectedRequestJSONBody, NSHTTPURLResponse *redirectHTTPResponse, id finalJSONResponse, NSError *errorResponse)
@@ -393,7 +394,8 @@
                      XCTAssertNil(redirectedRequestHeaders[@"Proxy-Authenticate"], @"Proxy-Authenticate header is preserved when following redirects");
                      XCTAssertNil(redirectedRequestHeaders[@"Proxy-Authorization"], @"Proxy-Authorization header is preserved when following redirects");
                      XCTAssertNil(redirectedRequestHeaders[@"WWW-Authenticate"], @"WWW-Authenticate header is preserved when following redirects");
-                     XCTAssertEqual(redirectedRequestHeaders[@"Preserved"], @"preserved", @"Regular header is not preserved when following redirects");
+                     XCTAssertEqual(redirectedRequestHeaders[@"Preserved1"], @"preserved", @"Regular header is not preserved when following redirects");
+                     XCTAssertEqual(redirectedRequestHeaders[@"Preserved2"], @"preserved", @"Regular header is not preserved when following redirects");
                  }];
 
                 [session finishTasksAndInvalidate];


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

The change in https://github.com/AliSoftware/OHHTTPStubs/pull/263 means a redirected request had the same headers as the original request (because it was a copy and not a brand new `NSURLRequest` instance).

While the new behavior was correct, it didn't account for "special headers" that URLSession "handles". The docs aren't entirely clear what that means, but we've at least confirmed it removes the "Authorization" headers as that poses a security risk, so this PR removes all those headers + a test.