### PR TITLE
Better nullability and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # OHHTTPStubs — CHANGELOG
 
+<!-- Add new release notes above the latest release. The new version number will get added last before the new release. -->
+
 ## [8.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/8.0.0)
 
 * Update default Swift Version to 5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 [@croig](https://github.com/CRoig)
 
 >Notes:
-> * No code changes were required (except from a little missing comma which caused a compilation error). Only xcshemes and xcodeproj were changed.
+> * No code changes were required (except from a little missing comma which caused a compilation error). Only xcschemes and xcodeproj were changed.
 
 ## [7.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/7.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OHHTTPStubs — CHANGELOG
 
-## [8.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/7.0.0)
+## [8.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/8.0.0)
 
 * Update default Swift Version to 5.0
 [@croig](https://github.com/CRoig)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 <!-- Add new release notes above the latest release. The new version number will get added last before the new release. -->
 
+* Fix clang static analysis warnings and use more idiomatic Objective-C error handling.
+  [@zeveisenberg](https://github.com/zeveisenberg)
+
 ## [8.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/8.0.0)
 
 * Update default Swift Version to 5.0

--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
@@ -93,7 +93,7 @@ extern NSString* const MocktailErrorDomain;
  * @return an array of stub descriptor that uniquely identifies the stub and can be later used to remove it with
  * `removeStub:`.
  */
-+(nullable NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
++(nullable NSArray<id<OHHTTPStubsDescriptor>> *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
 
 @end
 

--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.h
@@ -65,7 +65,7 @@ extern NSString* const MocktailErrorDomain;
  * @return a stub descriptor that uniquely identifies the stub and can be later used to remove it with
  * `removeStub:`.
  */
-+(id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
++(nullable id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
 
 /**
  * Add a stub given a file URL in the format of Mocktail as defined at https://github.com/square/objc-mocktail.
@@ -93,7 +93,7 @@ extern NSString* const MocktailErrorDomain;
  * @return an array of stub descriptor that uniquely identifies the stub and can be later used to remove it with
  * `removeStub:`.
  */
-+(NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
++(nullable NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error;
 
 @end
 

--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
@@ -59,11 +59,10 @@ NSString* const MocktailErrorDomain = @"Mocktail";
     }
 
     // Read the content of the directory
-    NSError *bError = nil;
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSArray *fileURLs = [fileManager contentsOfDirectoryAtURL:dirURL includingPropertiesForKeys:nil options:0 error:&bError];
+    NSArray *fileURLs = [fileManager contentsOfDirectoryAtURL:dirURL includingPropertiesForKeys:nil options:0 error:nil];
 
-    if (bError)
+    if (!fileURLs)
     {
         if (error)
         {
@@ -80,8 +79,8 @@ NSString* const MocktailErrorDomain = @"Mocktail";
         {
             continue;
         }
-        id<OHHTTPStubsDescriptor> descriptor = [[self class] stubRequestsUsingMocktail:fileURL error: &bError];
-        if (descriptor && !bError)
+        id<OHHTTPStubsDescriptor> descriptor = [[self class] stubRequestsUsingMocktail:fileURL error: nil];
+        if (descriptor)
         {
             [descriptorArray addObject:descriptor];
         }
@@ -114,7 +113,7 @@ NSString* const MocktailErrorDomain = @"Mocktail";
     NSStringEncoding originalEncoding;
     NSString *contentsOfFile = [NSString stringWithContentsOfURL:fileURL usedEncoding:&originalEncoding error:&bError];
 
-    if (!contentsOfFile || bError)
+    if (!contentsOfFile)
     {
         if (error)
         {
@@ -138,9 +137,9 @@ NSString* const MocktailErrorDomain = @"Mocktail";
 
     /* Handle Mocktail format, adapted from Mocktail implementation
        For more details on the file format, check out: https://github.com/square/objc-Mocktail */
-    NSRegularExpression *methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:&bError];
+    NSRegularExpression *methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:nil];
 
-    if (bError)
+    if (!methodRegex)
     {
         if (error)
         {
@@ -149,9 +148,9 @@ NSString* const MocktailErrorDomain = @"Mocktail";
         return nil;
     }
 
-    NSRegularExpression *absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:&bError];
+    NSRegularExpression *absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:nil];
 
-    if (bError)
+    if (!absoluteURLRegex)
     {
         if (error)
         {
@@ -165,8 +164,8 @@ NSString* const MocktailErrorDomain = @"Mocktail";
     NSMutableDictionary *headers = @{@"Content-Type":lines[3]}.mutableCopy;
 
     // From line 4 to '\n\n', expect HTTP response headers.
-    NSRegularExpression *headerPattern = [NSRegularExpression regularExpressionWithPattern:@"^([^:]+):\\s+(.*)" options:0 error:&bError];
-    if (bError)
+    NSRegularExpression *headerPattern = [NSRegularExpression regularExpressionWithPattern:@"^([^:]+):\\s+(.*)" options:0 error:nil];
+    if (!headerPattern)
     {
         if (error)
         {
@@ -177,8 +176,8 @@ NSString* const MocktailErrorDomain = @"Mocktail";
 
 
     // Allow bare Content-Type header on line 4 before named HTTP response headers
-    NSRegularExpression *bareContentTypePattern = [NSRegularExpression regularExpressionWithPattern:@"^([^:]+)+$" options:0 error:&bError];
-    if (bError)
+    NSRegularExpression *bareContentTypePattern = [NSRegularExpression regularExpressionWithPattern:@"^([^:]+)+$" options:0 error:nil];
+    if (!bareContentTypePattern)
     {
         if (error)
         {

--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
@@ -32,7 +32,7 @@ NSString* const MocktailErrorDomain = @"Mocktail";
 @implementation OHHTTPStubs (Mocktail)
 
 
-+(nullable NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
++(nullable NSArray<id<OHHTTPStubsDescriptor>> *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
 {
     NSURL *dirURL = [bundleOrNil?:[NSBundle bundleForClass:self.class] URLForResource:path withExtension:nil];
     if (!dirURL)
@@ -73,7 +73,7 @@ NSString* const MocktailErrorDomain = @"Mocktail";
     }
 
     //stub the Mocktail-formatted requests
-    NSMutableArray *descriptorArray = [[NSMutableArray alloc] initWithCapacity:fileURLs.count];
+    NSMutableArray<id<OHHTTPStubsDescriptor>> *descriptorArray = [[NSMutableArray alloc] initWithCapacity:fileURLs.count];
     for (NSURL *fileURL in fileURLs)
     {
         if (![fileURL.absoluteString hasSuffix:@".tail"])

--- a/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
+++ b/OHHTTPStubs/Sources/Mocktail/OHHTTPStubs+Mocktail.m
@@ -32,7 +32,7 @@ NSString* const MocktailErrorDomain = @"Mocktail";
 @implementation OHHTTPStubs (Mocktail)
 
 
-+(NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
++(nullable NSArray *)stubRequestsUsingMocktailsAtPath:(NSString *)path inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
 {
     NSURL *dirURL = [bundleOrNil?:[NSBundle bundleForClass:self.class] URLForResource:path withExtension:nil];
     if (!dirURL)
@@ -90,7 +90,7 @@ NSString* const MocktailErrorDomain = @"Mocktail";
     return descriptorArray;
 }
 
-+(id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
++(nullable id<OHHTTPStubsDescriptor>)stubRequestsUsingMocktailNamed:(NSString *)fileName inBundle:(nullable NSBundle*)bundleOrNil error:(NSError **)error
 {
     NSURL *responseURL = [bundleOrNil?:[NSBundle bundleForClass:self.class] URLForResource:fileName withExtension:@"tail"];
 

--- a/OHHTTPStubs/Sources/OHHTTPStubs.m
+++ b/OHHTTPStubs/Sources/OHHTTPStubs.m
@@ -43,7 +43,7 @@ static NSTimeInterval const kSlotTime = 0.25; // Must be >0. We will send a chun
 
 @interface OHHTTPStubs()
 + (instancetype)sharedInstance;
-@property(atomic, copy) NSMutableArray* stubDescriptors;
+@property(atomic, readonly) NSMutableArray* stubDescriptors;
 @property(atomic, assign) BOOL enabledState;
 @property(atomic, copy, nullable) void (^onStubActivationBlock)(NSURLRequest*, id<OHHTTPStubsDescriptor>, OHHTTPStubsResponse*);
 @property(atomic, copy, nullable) void (^onStubRedirectBlock)(NSURLRequest*, NSURLRequest*, id<OHHTTPStubsDescriptor>, OHHTTPStubsResponse*);

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -200,12 +200,13 @@
         XCTAssertNil(error, @"Error while getting cards.");
 
         NSArray *json = nil;
-        if(!error && [@"application/json" isEqual:response.MIMEType])
+        NSError *jsonError = nil;
+        if([@"application/json" isEqualToString:response.MIMEType])
         {
-            json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
         }
 
-        XCTAssertNotNil(json, @"The response is not a json object");
+        XCTAssertNotNil(json, @"The response is not a json object: %@", jsonError);
         XCTAssertEqual(json.count, 2, @"The response does not contain 2 cards");
         XCTAssertEqualObjects([json firstObject][@"amount"], @"$25.28", @"The first card amount does not match");
 

--- a/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/MocktailTests.m
@@ -66,6 +66,17 @@
     [self runLogin];
 }
 
+- (void)testMocktailFailsWithInvalidInputFile
+{
+    NSError *error = nil;
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    id<OHHTTPStubsDescriptor> descriptor = [OHHTTPStubs stubRequestsUsingMocktailNamed:@"invalid file name" inBundle:bundle error:&error];
+    XCTAssertNil(descriptor, @"Invalid input failed to produce nil result");
+    XCTAssertEqualObjects(error.domain, MocktailErrorDomain);
+    XCTAssertEqual(error.code, OHHTTPStubsMocktailErrorPathDoesNotExist);
+    XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], @"File 'invalid file name' does not exist.");
+}
+
 - (void)testMocktailsAtFolder
 {
     NSError *error = nil;
@@ -74,6 +85,28 @@
     XCTAssertNil(error, @"Error while stubbing Mocktails at folder 'MocktailFolder': %@", [error localizedDescription]);
     [self runLogin];
     [self runGetCards];
+}
+
+- (void)testMocktailsFailWithNonexistentFolder
+{
+    NSError *error = nil;
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    NSArray *descriptors = [OHHTTPStubs stubRequestsUsingMocktailsAtPath:@"invalid folder name" inBundle:bundle error:&error];
+    XCTAssertNil(descriptors, @"Invalid input failed to produce nil result");
+    XCTAssertEqualObjects(error.domain, MocktailErrorDomain);
+    XCTAssertEqual(error.code, OHHTTPStubsMocktailErrorPathDoesNotExist);
+    XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], @"Path 'invalid folder name' does not exist.");
+}
+
+- (void)testMocktailsFailWithNonFolderFile
+{
+    NSError *error = nil;
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    NSArray *descriptors = [OHHTTPStubs stubRequestsUsingMocktailsAtPath:@"login.tail" inBundle:bundle error:&error];
+    XCTAssertNil(descriptors, @"Invalid input failed to produce nil result");
+    XCTAssertEqualObjects(error.domain, MocktailErrorDomain);
+    XCTAssertEqual(error.code, OHHTTPStubsMocktailErrorPathIsNotFolder);
+    XCTAssertEqualObjects(error.userInfo[NSLocalizedDescriptionKey], @"Path 'login.tail' is not a folder.");
 }
 
 - (void)testMocktailHeaders

--- a/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
+++ b/OHHTTPStubs/UnitTests/Test Suites/NSURLSessionTests.m
@@ -89,7 +89,7 @@
             {
                 NSError *jsonError = nil;
                 NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-                XCTAssertNil(jsonError, @"Unexpected error deserializing JSON response");
+                XCTAssertNotNil(jsonObject, @"Unexpected error deserializing JSON response: %@", jsonError);
                 dataResponse = jsonObject;
             }
             [expectation fulfill];


### PR DESCRIPTION
### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Fixes #290

Also does more idiomatic error handling:

#### Wrong:

```objc
NSError *error;
NSArray *result = [someObject someMethod error:&error];
if (!error) {
    // assume success
}
```

#### Correct:
```objc
NSError *error;
NSArray *result = [someObject someMethod error:&error];
if (result) {
    // assume success
}
```

### Motivation and Context

The main motivation was addressing static analysis warnings I encountered when analyzing an Objective-C project. The error handling was just something I fixed along the way.

Note: I also added a couple of missing generics annotations which may affect the public interface. If they are imported into Swift, they will go from `[Any]` to `[OHHTTPStubsDescriptor]`. This is a breaking change for anyone who is using the output of this method in Swift.

Testing: I added a couple of missing tests for error throwing cases, and made sure all the tests were passing.