### PR TITLE
[issue 309] Added containsQueryParamsMatching(...) matcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OHHTTPStubs — CHANGELOG
 
+## [Future release]
+
+* Added `containsQueryParamsMatching(...)` matcher.
+  [@mcarti](https://github.com/mcarti)
+  [#309](https://github.com/AliSoftware/OHHTTPStubs/issues/309)
 
 ## [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0)
 

--- a/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
+++ b/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
@@ -381,6 +381,35 @@ class SwiftHelpersTests : XCTestCase {
       XCTAssert(matcher(req) == result, "containsQueryParams(\"\(params)\") matcher failed when testing url \(url)")
     }
   }
+    
+  @available(iOS 8.0, OSX 10.10, *)
+  func testContainsQueryParamsMatching() {
+    let regEx1: String = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$"
+    let regEx2: String = "en|fr|ru"
+    let params: [String: String?] = ["q":regEx1, "lang": regEx2]
+    let matcher = containsQueryParamsMatching(params)
+        
+    let urls = [
+      "foo://bar": false,
+      "foo://bar?q=1994-11-05T08:15:30.000Z": false,
+      "foo://bar?lang=en": false,
+      "foo://bar?q=1994-11-05T08:15:30.000Z&lang=en": true,
+      "foo://bar?q=2019-05-21T13:22:45.000Z&lang=fr": true,
+      "foo://bar?q=9999-99-99T99:99:99.999Z&lang=ru": true,
+      "foo://bar?q=1994-11-05T08:15:30.000Z&lang=ro": false,
+      "foo://bar?q=1994-11-05T08:15:30.000&lang=en": false
+    ]
+        
+    for (url, result) in urls {
+#if swift(>=3.0)
+      let req = URLRequest(url: URL(string: url)!)
+#else
+      let req = NSURLRequest(URL: NSURL(string: url)!)
+#endif
+            
+      XCTAssert(matcher(req) == result, "containsQueryParamsMatching(\"\(params)\") matcher failed when testing url \(url)")
+    }
+  }
 
   func testHasHeaderNamedIsTrue() {
 #if swift(>=3.0)


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [ ] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

New matcher added: `containsQueryParamsMatching(...)`. This matcher checks the presence of a list of parameters matching the RegExs given in a dictionary.


### Motivation and Context

I suggested to share this new matcher in the issue [#309](https://github.com/AliSoftware/OHHTTPStubs/issues/309).
The need is for checking the presence of dynamic parameters as timestamps or languages for example. 
Since there was no entry in the documentation for the containsQueryParams matcher, I didn't add one for this matcher.
