### PR TITLE
Fix warning in Xcode 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 * Added `hasFormBody(_:)` matcher.  
 [@417-72KI](https://github.com/417-72KI)
+* Added fix for Xcode 12 - Warnings related to iOS 8 support (Swift Package Manager) #328
+[@kikeenrique](https://github.com/kikeenrique)
 
 ## [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0)
 

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "OHHTTPStubs",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .watchOS(.v2), .tvOS(.v9)
+        .macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
…#328

<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Fix warning in Xcode 12. _The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99._

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To fix warning in Xcode 12

<!--- If it fixes an open issue, please link to the issue here. -->
#328

<!--- Please describe in detail how you tested your changes. --->
Runned tests in iOS lib and build Examples/SwiftPackageManager.