### PR TITLE
Added `hasJsonBody(_:)` matcher for array

### DIFF
--- a/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
+++ b/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
@@ -426,6 +426,26 @@ public func hasJsonBody(_ jsonObject: [AnyHashable : Any]) -> HTTPStubsTestBlock
 }
 #endif
 
+/**
+ * Matcher testing that the `NSURLRequest` body contains a JSON array with the same values
+ * - Parameter jsonArray: the JSON array to expect
+ *
+ * - Returns: a matcher that returns true if the `NSURLRequest`'s body contains a JSON array with the values as the parameter value
+ */
+#if swift(>=3.0)
+public func hasJsonBody(_ jsonArray: [Any]) -> HTTPStubsTestBlock {
+  return { req in
+    guard
+      let httpBody = req.ohhttpStubs_httpBody,
+      let jsonBody = (try? JSONSerialization.jsonObject(with: httpBody, options: [])) as? [Any]
+    else {
+      return false
+    }
+    return NSArray(array: jsonBody).isEqual(to: jsonArray)
+  }
+}
+#endif
+
 #if swift(>=3.0)
 /**
  * Matcher testing that the `NSURLRequest` content-type is `application/x-www-form-urlencoded` and body contains a query parameter

--- a/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
+++ b/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
@@ -523,6 +523,54 @@ class SwiftHelpersTests : XCTestCase {
 #endif
 
 #if swift(>=3.0)
+  func testHasJsonArrayBodyIsTrue() {
+    let jsonStringsAndObjects = [
+      // Exact match
+      ("[\"foo\", \"bar\", \"baz\", 42, \"qux\", true]",
+       ["foo", "bar", "baz", 42, "qux", true]),
+      // Newlines and indentations
+      ("[\"foo\", \"bar\", \n\"baz\", 42,       \"qux\", true]",
+       ["foo", "bar", "baz", 42, "qux", true]),
+      // Nested objects
+      ("[[ \"foo\", \"bar\", \"baz\" ], { \"qux\": true, \"quux\": [\"spam\", \"ham\", \"eggs\"] }]",
+       [["foo", "bar", "baz"], ["qux": true, "quux": ["spam", "ham", "eggs"]]]),
+    ]
+
+    for (jsonString, expectedJsonObject) in jsonStringsAndObjects {
+      var req = URLRequest(url: URL(string: "foo://bar")!)
+      req.httpBody = jsonString.data(using: .utf8)
+      let matchesJsonBody = hasJsonBody(expectedJsonObject)(req)
+
+      XCTAssertTrue(matchesJsonBody)
+    }
+  }
+#endif
+
+#if swift(>=3.0)
+  func testHasJsonArrayBodyIsFalse() {
+    let jsonStringsAndObjects = [
+      // Changed value
+      ("[ \"foo\", \"bar\" ]",
+       ["foo", "qux"]),
+      // Changed order
+      ("[ \"foo\", \"bar\" ]",
+       ["bar", "foo"]),
+      // Nested objects with changed order
+      ("[ { \"foo\": \"bar\", \"baz\": { \"qux\": true } }, { \"quux\": [ \"spam\", \"ham\", \"eggs\" ] } ]",
+       [["quux": ["spam", "ham", "eggs"]], ["foo": "bar", "baz": ["qux": true]]])
+    ] as [(String, [Any])]
+
+    for (jsonString, expectedJsonObject) in jsonStringsAndObjects {
+      var req = URLRequest(url: URL(string: "foo://bar")!)
+      req.httpBody = jsonString.data(using: .utf8)
+      let matchesJsonBody = hasJsonBody(expectedJsonObject)(req)
+
+      XCTAssertFalse(matchesJsonBody)
+    }
+  }
+#endif
+
+#if swift(>=3.0)
   @available(iOS 8.0, OSX 10.10, *)
   func testHasFormBodyIsTrue() {
     func assertMatchesFormBody(_ formBody: String, _ expectedKeyValues: [String: String?], file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

I've added an overloaded matcher `hasJsonBody` that tests whether the NSURLRequest body contains a JSON array with the values on same order.

### Motivation and Context

There is a matcher `hasJsonBody` for a JSON object ( created on #265 ).
Unfortunately, it cannot be used when root of an object is an array (e.g. `["foo", "bar"]`).
