### PR TITLE
Xcode 14 - Warnings related to iOS 11 support (Swift Package Manager)

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,73 @@
+name: project
+
+on: ["push", "workflow_dispatch"]
+
+jobs:
+  build-app:
+    name: Build App
+    strategy:
+        fail-fast: false
+        matrix:
+            os: [macos-13]
+            build_type: ['release']
+            run-config:
+                - { xcode_version: '13.4.1', simulator: 'name=iPhone 13 Pro' }
+                - { xcode_version: '14.0.1', simulator: 'name=iPhone 14 Pro' }
+                - { xcode_version: '14.3.1', simulator: 'name=iPhone 14 Pro' }
+                - { xcode_version: '15.0.1', simulator: 'name=iPhone 15 Pro' }
+
+    runs-on: ${{ matrix.os }}
+    env:
+        DEVELOPER_DIR: /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app/Contents/Developer
+        DESTINATION: platform=iOS Simulator,${{ matrix.run-config['simulator'] }}
+    steps:
+        - uses: actions/checkout@v3
+        - name: Brew Update
+          run: |
+            brew update
+        - name: Install xcbeautify
+          run: |
+            brew install xcbeautify
+        - name: List Simulators
+          run: |
+            xcrun simctl list
+        - name: Prepare shell
+          run: |
+            set -o pipefail
+        - name: Build
+          run: |
+           env NSUnbufferedIO=YES xcodebuild -project "Ruka.xcodeproj" -scheme "Ruka" -destination "${DESTINATION}" clean build | xcbeautify
+    
+  test-App:
+    name: Test App
+    strategy:
+        fail-fast: false
+        matrix:
+            os: [macos-13]
+            build_type: ['release']
+            run-config:
+                - { xcode_version: '13.4.1', simulator: 'name=iPhone 13 Pro' }
+                - { xcode_version: '14.0.1', simulator: 'name=iPhone 14 Pro' }
+                - { xcode_version: '14.3.1', simulator: 'name=iPhone 14 Pro' }
+                - { xcode_version: '15.0.1', simulator: 'name=iPhone 15 Pro' }
+    runs-on: ${{ matrix.os }}
+    env:
+        DEVELOPER_DIR: /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app/Contents/Developer
+        DESTINATION: "platform=iOS Simulator,${{ matrix.run-config['simulator'] }}"
+    steps:
+        - uses: actions/checkout@v3
+        - name: Brew Update
+          run: |
+            brew update
+        - name: Install xcbeautify
+          run: |
+            brew install xcbeautify
+        - name: List Simulators
+          run: |
+            xcrun simctl list
+        - name: Prepare shell
+          run: |
+            set -o pipefail
+        - name: Test
+          run: |
+            env NSUnbufferedIO=YES xcodebuild -project "Ruka.xcodeproj" -scheme "Ruka" -destination "${DESTINATION}" clean test | xcbeautify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 [@417-72KI](https://github.com/417-72KI)
 * Added fix for Xcode 12 - Warnings related to iOS 8 support (Swift Package Manager) #328
 [@kikeenrique](https://github.com/kikeenrique)
+* OHHTPStubs frameworks: Put Headers phase before Sources phase.
+  [@byohay](https://github.com/byohay)
 
 ## [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+* Added fix for Xcode 14 - Warnings related to iOS 11 support (Swift Package Manager)
+[@kikeenrique](https://github.com/kikeenrique)
+
+
+## [9.1.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.1.0)
+
 * Added `hasFormBody(_:)` matcher.  
 [@417-72KI](https://github.com/417-72KI)
 * Added fix for Xcode 12 - Warnings related to iOS 8 support (Swift Package Manager) #328

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 [@417-72KI](https://github.com/417-72KI)
 * Added fix for Xcode 12 - Warnings related to iOS 8 support (Swift Package Manager) #328
 [@kikeenrique](https://github.com/kikeenrique)
+* Export OHHTTPStubs from OHHTTPStubsSwift so that SwiftPM users don't need to import both of them #353 [@manicmaniac](https://github.com/manicmaniac)
 
 ## [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0)
 

--- a/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -695,9 +695,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 095981E019806A7900807DBE /* Build configuration list for PBXNativeTarget "OHHTTPStubs Mac Framework" */;
 			buildPhases = (
+				095981BF19806A7900807DBE /* Headers */,
 				095981BD19806A7900807DBE /* Sources */,
 				095981BE19806A7900807DBE /* Frameworks */,
-				095981BF19806A7900807DBE /* Headers */,
 				095981C019806A7900807DBE /* Resources */,
 			);
 			buildRules = (
@@ -732,9 +732,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 725CD9B21A9EB65200F84C8B /* Build configuration list for PBXNativeTarget "OHHTTPStubs iOS Framework" */;
 			buildPhases = (
+				725CD9981A9EB65100F84C8B /* Headers */,
 				725CD9961A9EB65100F84C8B /* Sources */,
 				725CD9971A9EB65100F84C8B /* Frameworks */,
-				725CD9981A9EB65100F84C8B /* Headers */,
 				725CD9991A9EB65100F84C8B /* Resources */,
 			);
 			buildRules = (
@@ -769,9 +769,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAA436A21BE1598D000E9E99 /* Build configuration list for PBXNativeTarget "OHHTTPStubs tvOS Framework" */;
 			buildPhases = (
+				EAA436981BE1598D000E9E99 /* Headers */,
 				EAA4368E1BE1598D000E9E99 /* Sources */,
 				EAA436971BE1598D000E9E99 /* Frameworks */,
-				EAA436981BE1598D000E9E99 /* Headers */,
 				EAA436A11BE1598D000E9E99 /* Resources */,
 			);
 			buildRules = (

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,7 +1,9 @@
 // swift-tools-version:5.0
 import PackageDescription
 
-#if swift(>=5.7)
+#if swift(>=5.9)
+let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_13), .iOS(.v12), .watchOS(.v4), .tvOS(.v12)]
+#elseif swift(>=5.7)
 let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_13), .iOS(.v11), .watchOS(.v4), .tvOS(.v11)]
 #elseif swift(>=5.0)
 let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9)]

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,11 +1,15 @@
 // swift-tools-version:5.0
 import PackageDescription
 
+#if swift(>=5.7)
+let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_13), .iOS(.v11), .watchOS(.v4), .tvOS(.v11)]
+#elseif swift(>=5.0)
+let platforms: [PackageDescription.SupportedPlatform] = [.macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9)]
+#endif
+
 let package = Package(
     name: "OHHTTPStubs",
-    platforms: [
-        .macOS(.v10_10), .iOS(.v9), .watchOS(.v2), .tvOS(.v9)
-    ],
+    platforms: platforms,
     products: [
         .library(
             name: "OHHTTPStubs",

--- a/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
+++ b/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
@@ -28,7 +28,7 @@
 
 import Foundation
 #if SWIFT_PACKAGE
-import OHHTTPStubs
+@_exported import OHHTTPStubs
 #endif
 
 #if !swift(>=3.0)

--- a/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
+++ b/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
@@ -10,7 +10,6 @@ import Foundation
 import XCTest
 #if SWIFT_PACKAGE
 @testable import OHHTTPStubsSwift
-@testable import OHHTTPStubs
 #else
 @testable import OHHTTPStubs
 #endif


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Hi,
I would like to contribute fixing a recent warning.

The new Xcode 14 uses next SDKs as base: iOS 11.0, macOS 10.13, watchOS 4.0 and tvOS 11.0. Compiling in this Xcode shows a warning.
Handle this restrictions relying on swift version (which is also vinculated to each Xcode version).

Regards and comments welcomed

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes a warning
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Run project tests and compile on each platform.