### PR TITLE
Export OHHTTPStubs from OHHTTPStubsSwift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 [@417-72KI](https://github.com/417-72KI)
 * Added fix for Xcode 12 - Warnings related to iOS 8 support (Swift Package Manager) #328
 [@kikeenrique](https://github.com/kikeenrique)
+* Export OHHTTPStubs from OHHTTPStubsSwift so that SwiftPM users don't need to import both of them #353 [@manicmaniac](https://github.com/manicmaniac)
 
 ## [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0)
 

--- a/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
+++ b/Sources/OHHTTPStubsSwift/OHHTTPStubsSwift.swift
@@ -28,7 +28,7 @@
 
 import Foundation
 #if SWIFT_PACKAGE
-import OHHTTPStubs
+@_exported import OHHTTPStubs
 #endif
 
 #if !swift(>=3.0)

--- a/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
+++ b/Tests/OHHTTPStubsSwiftTests/SwiftHelpersTests.swift
@@ -10,7 +10,6 @@ import Foundation
 import XCTest
 #if SWIFT_PACKAGE
 @testable import OHHTTPStubsSwift
-@testable import OHHTTPStubs
 #else
 @testable import OHHTTPStubs
 #endif


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

<!--- Describe your changes in detail -->

Export OHHTTPStubs from OHHTTPStubsSwift using [`@_exported`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_exported) so that users doesn't need to import both of them.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Previously SwiftPM users should import both OHHTTPStubs and OHHTTPStubsSwift, contrary to CocoaPods users who need to import only OHHTTPStubs.
This difference is small but an obstacle for migrating to Swift Package Manager.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

1. Firstly I removed `import OHHTTPStubs` statement from Tests/OHHTTPStubsSwiftTests/SwiftHelperTests.swift. This change made tests fail.
2. Then add `@_exported` modifier to import statement, then the test passed.