### PR TITLE
Xcode 14 - Warnings related to tvOS 11 support (Swift Package Manager)

### DIFF
--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "OHHTTPStubs",
     platforms: [
-        .macOS(.v10_10), .iOS(.v11), .watchOS(.v2), .tvOS(.v9)
+        .macOS(.v10_10), .iOS(.v11), .watchOS(.v2), .tvOS(.v11)
     ],
     products: [
         .library(


### PR DESCRIPTION
<!-- Thanks for contributing to OHHTTPStubs! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've checked that all new and existing tests pass
- [x] I've updated the documentation if necessary
- [x] I've added an entry in the CHANGELOG to credit myself

### Description

Hi,
I would like to contribute fixing a warning.

In Xcode 14 SDKs are: iOS 11.0, macOS 10.13, watchOS 4.0 and tvOS 11.0. 
Still missing the tvOS minimal version.

Regards and comments welcomed

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes a warning
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->
Run project tests and compile on each platform.